### PR TITLE
Improve createAdapter return type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,96 +20,96 @@
         "semver": "7.7.1",
         "typescript": "5.8.2",
         "typescript-eslint": "8.26.1",
-        "valdres": "0.2.0-pre.18",
-        "valdres-react": "0.2.0-pre.18",
+        "valdres": "0.2.0-pre.24",
+        "valdres-react": "0.2.0-pre.24",
       },
     },
     "packages/@roc-db/in-memory": {
       "name": "@roc-db/in-memory",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.90",
-        "roc-db": "0.2.0-pre.90",
+        "@roc-db/test-utils": "0.2.0-pre.94",
+        "roc-db": "0.2.0-pre.94",
         "zod": "4.0.14",
       },
       "peerDependencies": {
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
         "zod": ">=4.0.0",
       },
     },
     "packages/@roc-db/indexed-db": {
       "name": "@roc-db/indexed-db",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.90",
+        "@roc-db/test-utils": "0.2.0-pre.94",
         "fake-indexeddb": "6.0.1",
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
         "zod": "4.0.14",
       },
       "peerDependencies": {
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
         "zod": ">=4.0.0",
       },
     },
     "packages/@roc-db/postgres": {
       "name": "@roc-db/postgres",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "dependencies": {
         "postgres": "3.4.5",
       },
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.90",
-        "roc-db": "0.2.0-pre.90",
+        "@roc-db/test-utils": "0.2.0-pre.94",
+        "roc-db": "0.2.0-pre.94",
         "zod": "4.0.14",
       },
       "peerDependencies": {
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
         "zod": ">=4.0.0",
       },
     },
     "packages/@roc-db/test-utils": {
       "name": "@roc-db/test-utils",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "devDependencies": {
         "@faker-js/faker": "9.7.0",
-        "@roc-db/in-memory": "0.2.0-pre.90",
+        "@roc-db/in-memory": "0.2.0-pre.94",
         "@types/bun": "1.2.19",
         "@types/sanitize-html": "2.13.0",
         "bun": "1.2.19",
         "expect-type": "1.2.0",
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
       },
       "peerDependencies": {
-        "roc-db": "0.2.0-pre.90",
+        "roc-db": "0.2.0-pre.94",
         "zod": ">=4.0.0",
       },
     },
     "packages/@roc-db/valdres": {
       "name": "@roc-db/valdres",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "devDependencies": {
         "@faker-js/faker": "9.3.0",
-        "@roc-db/test-utils": "0.2.0-pre.90",
+        "@roc-db/test-utils": "0.2.0-pre.94",
         "@types/bun": "1.2.19",
         "bun": "1.2.19",
         "expect-type": "1.1.0",
         "prettier": "3.4.1",
-        "roc-db": "0.2.0-pre.90",
-        "valdres": "0.2.0-pre.18",
+        "roc-db": "0.2.0-pre.94",
+        "valdres": "0.2.0-pre.24",
       },
       "peerDependencies": {
-        "roc-db": "0.2.0-pre.90",
-        "valdres": "0.2.0-pre.18",
+        "roc-db": "0.2.0-pre.94",
+        "valdres": "0.2.0-pre.24",
         "zod": ">=4.0.0",
       },
     },
     "packages/roc-db": {
       "name": "roc-db",
-      "version": "0.2.0-pre.90",
+      "version": "0.2.0-pre.94",
       "devDependencies": {
-        "@roc-db/in-memory": "0.2.0-pre.90",
-        "@roc-db/indexed-db": "0.2.0-pre.90",
-        "@roc-db/test-utils": "0.2.0-pre.90",
+        "@roc-db/in-memory": "0.2.0-pre.94",
+        "@roc-db/indexed-db": "0.2.0-pre.94",
+        "@roc-db/test-utils": "0.2.0-pre.94",
         "@types/bun": "1.2.19",
         "bun": "1.2.19",
         "expect-type": "1.1.0",
@@ -690,7 +690,7 @@
 
     "valdres": ["valdres@0.2.0-pre.18", "", {}, "sha512-dqA778sE6WR/HQfgmuzEfkFUisLnzK1H9XrENmAXA3Mn8B6WjpALc2i8fvStTear4aD9CuqvjZU2CV0gIXMmPQ=="],
 
-    "valdres-react": ["valdres-react@0.2.0-pre.18", "", { "dependencies": { "valdres": "0.2.0-pre.18" }, "peerDependencies": { "react": ">=18" } }, "sha512-JU80wl1w999B5ysrFZ59yB6UNecrgUzKUYjX+PgM9iOvzC0TNxo+qj3edDZTx+LXR7amAVcbOZR9ZF720jMYpQ=="],
+    "valdres-react": ["valdres-react@0.2.0-pre.18", "", { "dependencies": { "valdres": "0.2.0-pre.24" }, "peerDependencies": { "react": ">=18" } }, "sha512-JU80wl1w999B5ysrFZ59yB6UNecrgUzKUYjX+PgM9iOvzC0TNxo+qj3edDZTx+LXR7amAVcbOZR9ZF720jMYpQ=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
@@ -731,6 +731,8 @@
     "@roc-db/valdres/expect-type": ["expect-type@1.1.0", "", {}, "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA=="],
 
     "@roc-db/valdres/prettier": ["prettier@3.4.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg=="],
+
+    "@roc-db/valdres/valdres": ["valdres@0.2.0-pre.24", "", {}, "sha512-C3babmwNXSTa08nx9Mu1/zZo36wQpFBpUQ/k5QYqxih34EhClSMJJv2C04e8zdGdbwo1yGO/N4c+Vo1d0pbqsA=="],
 
     "@tufjs/models/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "semver": "7.7.1",
         "typescript": "5.8.2",
         "typescript-eslint": "8.26.1",
-        "valdres": "0.2.0-pre.18",
-        "valdres-react": "0.2.0-pre.18"
+        "valdres": "0.2.0-pre.24",
+        "valdres-react": "0.2.0-pre.24"
     }
 }

--- a/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
+++ b/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
@@ -1,32 +1,22 @@
 import {
     createAdapter,
+    type CreateAdapterOptions,
+    type EntityN,
     Snowflake,
     type Operation,
-    type Session,
 } from "roc-db"
 import * as functions from "./functions"
-import type { z } from "zod"
-
-type Entity = z.ZodObject<{
-    entity: z.ZodLiteral<string>
-}>
 
 export const createInMemoryAdapter = <
     const Operations extends readonly Operation[],
-    const Entities extends readonly Entity[],
+    const Entities extends readonly EntityN[],
 >({
     operations,
     entities,
     snowflake = new Snowflake(1, 1),
     optimistic = true,
     session,
-}: {
-    operations: Operations
-    entities: Entities
-    snowflake?: Snowflake
-    optimistic?: boolean
-    session: Session
-}) => {
+}: CreateAdapterOptions<Operations, Entities>) => {
     return createAdapter(
         {
             name: "in-memory",

--- a/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
+++ b/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
@@ -1,7 +1,6 @@
 import {
     createAdapter,
     Snowflake,
-    type Adapter,
     type Operation,
     type Session,
 } from "roc-db"
@@ -13,7 +12,6 @@ type Entity = z.ZodObject<{
 }>
 
 export const createInMemoryAdapter = <
-    const Name extends string,
     const Operations extends readonly Operation[],
     const Entities extends readonly Entity[],
 >({
@@ -31,7 +29,7 @@ export const createInMemoryAdapter = <
 }) => {
     return createAdapter(
         {
-            name: "in-memory" as Name,
+            name: "in-memory",
             operations,
             entities,
             functions,
@@ -45,5 +43,5 @@ export const createInMemoryAdapter = <
             entitiesUnique: new Map(),
             entitiesIndex: new Map(),
         },
-    ) as Adapter
+    )
 }

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
@@ -1,4 +1,9 @@
-import { createAdapter, Snowflake, type Operation } from "roc-db"
+import {
+    createAdapter,
+    type CreateAdapterOptions,
+    Snowflake,
+    type Operation,
+} from "roc-db"
 import * as functions from "./functions"
 
 export const createIndexedDBAdapter = <
@@ -9,13 +14,7 @@ export const createIndexedDBAdapter = <
     session,
     dbName = "roc-db",
     optimistic = false,
-}: {
-    operations: Operations
-    entities: readonly any[]
-    session: any
-    dbName?: string
-    optimistic?: boolean
-}) => {
+}: CreateAdapterOptions<Operations> & { dbName?: string }) => {
     return createAdapter(
         {
             name: "indexed-db",

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
@@ -1,12 +1,20 @@
-import { createAdapter, Snowflake, type Adapter } from "roc-db"
+import { createAdapter, Snowflake, type Operation } from "roc-db"
 import * as functions from "./functions"
 
-export const createIndexedDBAdapter = ({
+export const createIndexedDBAdapter = <
+    const Operations extends readonly Operation[],
+>({
     operations,
     entities,
     session,
     dbName = "roc-db",
     optimistic = false,
+}: {
+    operations: Operations
+    entities: readonly any[]
+    session: any
+    dbName?: string
+    optimistic?: boolean
 }) => {
     return createAdapter(
         {
@@ -23,5 +31,5 @@ export const createIndexedDBAdapter = ({
             dbName,
             version: 1,
         },
-    ) as Adapter
+    )
 }

--- a/packages/@roc-db/postgres/src/createPostgresAdapter.ts
+++ b/packages/@roc-db/postgres/src/createPostgresAdapter.ts
@@ -1,7 +1,7 @@
 import {
     createAdapter,
+    type CreateAdapterOptions,
     Snowflake,
-    type Entity,
     type Operation,
 } from "roc-db"
 import * as functions from "./functions"
@@ -21,11 +21,7 @@ export const createPostgresAdapter = <
     onTransactionStart,
     onTransactionEnd,
     snowflake = new Snowflake(1, 1),
-}: {
-    operations: Operations
-    entities: readonly Entity[]
-    getClient?: any
-} & PostgresEngineOpts) => {
+}: CreateAdapterOptions<Operations> & PostgresEngineOpts & { getClient?: any }) => {
     return createAdapter(
         {
             name: "postgres",

--- a/packages/@roc-db/postgres/src/createPostgresAdapter.ts
+++ b/packages/@roc-db/postgres/src/createPostgresAdapter.ts
@@ -1,14 +1,15 @@
 import {
     createAdapter,
     Snowflake,
-    type Adapter,
     type Entity,
     type Operation,
 } from "roc-db"
 import * as functions from "./functions"
 import type { PostgresEngineOpts } from "./types/PostgresEngineOpts"
 
-export const createPostgresAdapter = ({
+export const createPostgresAdapter = <
+    const Operations extends readonly Operation[],
+>({
     operations,
     entities,
     client,
@@ -21,7 +22,7 @@ export const createPostgresAdapter = ({
     onTransactionEnd,
     snowflake = new Snowflake(1, 1),
 }: {
-    operations: readonly Operation[]
+    operations: Operations
     entities: readonly Entity[]
     getClient?: any
 } & PostgresEngineOpts) => {
@@ -44,5 +45,5 @@ export const createPostgresAdapter = ({
             onTransactionStart,
             onTransactionEnd,
         },
-    ) as Adapter
+    )
 }

--- a/packages/@roc-db/test-utils/src/setup/index.ts
+++ b/packages/@roc-db/test-utils/src/setup/index.ts
@@ -1,16 +1,16 @@
 import { expect } from "bun:test"
-import type { ZodSchema } from "zod"
+import type { ZodType } from "zod"
 
-const toMatchZodSchema = (received: any, schema: ZodSchema) => {
+const toMatchZodType = (received: any, schema: ZodType) => {
     const res = schema.safeParse(received)
     return { pass: res.success, message: () => res.error?.message }
 }
 
 // @ts-ignore
-expect.extend({ toMatchZodSchema })
+expect.extend({ toMatchZodType })
 
 interface CustomMatchers {
-    toMatchZodSchema(schema: ZodSchema): any
+    toMatchZodType(schema: ZodType): any
 }
 
 declare module "bun:test" {

--- a/packages/@roc-db/valdres/package.json
+++ b/packages/@roc-db/valdres/package.json
@@ -23,11 +23,11 @@
         "roc-db": "0.2.0-pre.94",
         "expect-type": "1.1.0",
         "prettier": "3.4.1",
-        "valdres": "0.2.0-pre.18"
+        "valdres": "0.2.0-pre.24"
     },
     "peerDependencies": {
         "roc-db": "0.2.0-pre.94",
-        "valdres": "0.2.0-pre.18",
+        "valdres": "0.2.0-pre.24",
         "zod": ">=4.0.0"
     },
     "keywords": [],

--- a/packages/@roc-db/valdres/src/createValdresAdapter.ts
+++ b/packages/@roc-db/valdres/src/createValdresAdapter.ts
@@ -2,7 +2,6 @@ import {
     createAdapter,
     type Adapter,
     type Entity,
-    type Mutation,
     Snowflake,
     type Operation,
     type Ref,
@@ -14,10 +13,37 @@ import {
     type Store,
     type AtomFamily,
     type TransactionInterface,
-    type Atom,
 } from "valdres"
 
-export const createValdresAdapter = <Session>({
+export type ValdresEngineOptions = {
+    txn?: TransactionInterface
+    rootTxn?: TransactionInterface
+    store?: Store
+    scopedStore?: Store
+    entityAtom: AtomFamily<any, any>
+    mutationAtom: AtomFamily<any, any>
+    entityUniqueAtom: AtomFamily<any, any>
+    entityIndexAtom: AtomFamily<any, any>
+}
+
+export type ValdresAdapterOptions<
+    Operations extends readonly Operation[] = readonly Operation[],
+> = {
+    operations: Operations
+    entities: readonly Entity[]
+    changeSetRef?: Ref
+    session: any
+    optimistic?: boolean
+    snowflake?: Snowflake
+    async?: boolean
+    validateCreate?: (...args: any[]) => void
+    validateUpdate?: (...args: any[]) => void
+    validateDelete?: (...args: any[]) => void
+} & ValdresEngineOptions
+
+export const createValdresAdapter = <
+    const Operations extends readonly Operation[],
+>({
     operations,
     entities,
     store, // = createStore(),
@@ -35,25 +61,10 @@ export const createValdresAdapter = <Session>({
     validateCreate,
     validateUpdate,
     validateDelete,
-}: {
-    operations: readonly Operation[]
-    entities: readonly Entity[]
-    store?: Store
-    rootTxn?: TransactionInterface
-    txn?: TransactionInterface
-    entityAtom: AtomFamily<string, Entity | null>
-    mutationAtom: AtomFamily<string, Mutation | null>
-    entityUniqueAtom: AtomFamily<Ref, [string]>
-    entityIndexAtom: AtomFamily<Ref, [string, string, string]>
-    changeSetRef?: Ref
-    session: Session
-    optimistic: boolean
-    snowflake?: Snowflake
-    async?: boolean
-    validateCreate?: () => void
-    validateUpdate?: () => void
-    validateDelete?: () => void
-}) => {
+}: ValdresAdapterOptions<Operations>): Adapter<
+    Operations,
+    ValdresEngineOptions
+> => {
     if (!entityAtom) throw new Error("entityAtom is required")
     if (!mutationAtom) throw new Error("mutationAtom is required")
     if (!entityUniqueAtom) throw new Error("entityUniqueAtom is required")
@@ -72,8 +83,7 @@ export const createValdresAdapter = <Session>({
             validateUpdate,
             validateDelete,
             async,
-            // initChangeSetOnce: true,
-        },
+        } as any,
         {
             txn,
             rootTxn,
@@ -85,5 +95,5 @@ export const createValdresAdapter = <Session>({
             // entityRefListAtom = atomFamily<string, string[]>([]),
             // mutationActions,
         },
-    ) as Adapter
+    )
 }

--- a/packages/@roc-db/valdres/src/createValdresAdapter.ts
+++ b/packages/@roc-db/valdres/src/createValdresAdapter.ts
@@ -1,10 +1,9 @@
 import {
     createAdapter,
     type Adapter,
-    type Entity,
+    type CreateAdapterOptions,
     Snowflake,
     type Operation,
-    type Ref,
 } from "roc-db"
 import * as functions from "./functions"
 import {
@@ -28,18 +27,7 @@ export type ValdresEngineOptions = {
 
 export type ValdresAdapterOptions<
     Operations extends readonly Operation[] = readonly Operation[],
-> = {
-    operations: Operations
-    entities: readonly Entity[]
-    changeSetRef?: Ref
-    session: any
-    optimistic?: boolean
-    snowflake?: Snowflake
-    async?: boolean
-    validateCreate?: (...args: any[]) => void
-    validateUpdate?: (...args: any[]) => void
-    validateDelete?: (...args: any[]) => void
-} & ValdresEngineOptions
+> = CreateAdapterOptions<Operations> & ValdresEngineOptions
 
 export const createValdresAdapter = <
     const Operations extends readonly Operation[],

--- a/packages/roc-db/src/Entity.ts
+++ b/packages/roc-db/src/Entity.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema, type ZodObject } from "zod"
+import { z, type ZodObject } from "zod"
 import { refSchemaGenerator } from "./schemas/generators/refSchemaGenerator"
 import { TimestampWithMutationRefSchema } from "./schemas/TimestampWithMutationRefSchema"
 

--- a/packages/roc-db/src/createAdapter.ts
+++ b/packages/roc-db/src/createAdapter.ts
@@ -6,6 +6,7 @@ import { createPageEntitiesOperation } from "./operations/createPageEntitiesOper
 import { pageMutations } from "./operations/pageMutations"
 import { redo } from "./operations/redo"
 import { undo } from "./operations/undo"
+import type { Adapter } from "./types/Adapter"
 import type { AdapterFunctions } from "./types/AdapterFunctions"
 import type { Mutation } from "./types/Mutation"
 import type { Operation } from "./types/Operation"
@@ -46,7 +47,7 @@ export const createAdapter = <
 >(
     adapterOptions: AdapterOptions<Operations, Entities, EngineOptions>,
     engineOptions: EngineOptions = {} as EngineOptions,
-) => {
+): Adapter<Operations, EngineOptions> => {
     const allOperations = [
         pageMutations,
         createPageEntitiesOperation(adapterOptions.entities),
@@ -86,7 +87,7 @@ export const createAdapter = <
         ),
     )
 
-    const adapter = {
+    const adapter: Record<string, any> = {
         get _name() {
             return adapterOptions.name
         },
@@ -155,5 +156,5 @@ export const createAdapter = <
             )
     }
 
-    return adapter
+    return adapter as Adapter<Operations, EngineOptions>
 }

--- a/packages/roc-db/src/createAdapter.ts
+++ b/packages/roc-db/src/createAdapter.ts
@@ -11,6 +11,7 @@ import type { AdapterFunctions } from "./types/AdapterFunctions"
 import type { Mutation } from "./types/Mutation"
 import type { Operation } from "./types/Operation"
 import type { Ref } from "./types/Ref"
+import type { Session } from "./types/Session"
 import { Snowflake } from "./utils/Snowflake"
 import { generateRef } from "./utils/generateRef"
 
@@ -20,32 +21,37 @@ export type EntityN = z.ZodObject<{
     // payload: z.ZodTypeAny
 }>
 
-type AdapterOptions<
+export type CreateAdapterOptions<
     Operations extends readonly Operation[] = [],
     Entities extends readonly EntityN[] = [],
-    EngineOptions extends {} = {},
 > = {
-    name: string
-    functions: AdapterFunctions<EngineOptions>
     operations: Operations
     entities: Entities
-    changeSetRefs: Ref[]
-    snowflake: Snowflake
-    session: {
-        identityRef: string
-        sessionRef?: string
-        [key: string]: any
-    }
+    snowflake?: Snowflake
+    session: Session
     async?: boolean
     changeSetRef?: Ref
     optimistic?: boolean
+    validateCreate?: (...args: any[]) => void
+    validateUpdate?: (...args: any[]) => void
+    validateDelete?: (...args: any[]) => void
+}
+
+type InternalAdapterOptions<
+    Operations extends readonly Operation[] = [],
+    Entities extends readonly EntityN[] = [],
+    EngineOptions extends {} = {},
+> = CreateAdapterOptions<Operations, Entities> & {
+    name: string
+    snowflake: Snowflake
+    functions: AdapterFunctions<EngineOptions>
 }
 export const createAdapter = <
     const Operations extends readonly Operation[],
     const Entities extends readonly EntityN[],
     const EngineOptions extends {} = {},
 >(
-    adapterOptions: AdapterOptions<Operations, Entities, EngineOptions>,
+    adapterOptions: InternalAdapterOptions<Operations, Entities, EngineOptions>,
     engineOptions: EngineOptions = {} as EngineOptions,
 ): Adapter<Operations, EngineOptions> => {
     const allOperations = [
@@ -87,7 +93,7 @@ export const createAdapter = <
         ),
     )
 
-    const adapter: Record<string, any> = {
+    const adapter = {
         get _name() {
             return adapterOptions.name
         },
@@ -137,24 +143,26 @@ export const createAdapter = <
             )
         },
         ...operationsMap,
-    }
-    if (adapterOptions.optimistic) {
-        adapter.loadMutations = (mutations: Mutation[]) =>
-            loadMutations(
-                adapterOptions,
-                engineOptions,
-                mutations,
-                allOperations,
-            )
-    } else {
-        adapter.persistOptimisticMutations = (mutations: Mutation[]) =>
-            persistOptimisticMutations(
-                adapterOptions,
-                engineOptions,
-                mutations,
-                allOperations,
-            )
-    }
+        ...(adapterOptions.optimistic
+            ? {
+                  loadMutations: (mutations: Mutation[]) =>
+                      loadMutations(
+                          adapterOptions,
+                          engineOptions,
+                          mutations,
+                          allOperations,
+                      ),
+              }
+            : {
+                  persistOptimisticMutations: (mutations: Mutation[]) =>
+                      persistOptimisticMutations(
+                          adapterOptions,
+                          engineOptions,
+                          mutations,
+                          allOperations,
+                      ),
+              }),
+    } as unknown as Adapter<Operations, EngineOptions>
 
-    return adapter as Adapter<Operations, EngineOptions>
+    return adapter
 }

--- a/packages/roc-db/src/createAdapter.ts
+++ b/packages/roc-db/src/createAdapter.ts
@@ -37,21 +37,16 @@ export type CreateAdapterOptions<
     validateDelete?: (...args: any[]) => void
 }
 
-type InternalAdapterOptions<
-    Operations extends readonly Operation[] = [],
-    Entities extends readonly EntityN[] = [],
-    EngineOptions extends {} = {},
-> = CreateAdapterOptions<Operations, Entities> & {
-    name: string
-    snowflake: Snowflake
-    functions: AdapterFunctions<EngineOptions>
-}
 export const createAdapter = <
     const Operations extends readonly Operation[],
     const Entities extends readonly EntityN[],
     const EngineOptions extends {} = {},
 >(
-    adapterOptions: InternalAdapterOptions<Operations, Entities, EngineOptions>,
+    adapterOptions: CreateAdapterOptions<Operations, Entities> & {
+        name: string
+        snowflake: Snowflake
+        functions: AdapterFunctions<EngineOptions>
+    },
     engineOptions: EngineOptions = {} as EngineOptions,
 ): Adapter<Operations, EngineOptions> => {
     const allOperations = [

--- a/packages/roc-db/src/errors/NotFoundError.ts
+++ b/packages/roc-db/src/errors/NotFoundError.ts
@@ -1,4 +1,4 @@
-import { Ref } from "../types/Ref"
+import { type Ref } from "../types/Ref"
 
 export class NotFoundError extends Error {
     constructor(ref: Ref) {

--- a/packages/roc-db/src/index.ts
+++ b/packages/roc-db/src/index.ts
@@ -1,4 +1,5 @@
 export { createAdapter } from "./createAdapter"
+export type { CreateAdapterOptions, EntityN } from "./createAdapter"
 export { readOperation } from "./readOperation"
 export { writeOperation } from "./writeOperation"
 export { Entity } from "./Entity"

--- a/packages/roc-db/src/lib/validateOutput.ts
+++ b/packages/roc-db/src/lib/validateOutput.ts
@@ -1,9 +1,9 @@
-import type { ZodSchema } from "zod"
+import type { ZodType } from "zod"
 import type { WriteRequest } from "../types/WriteRequest"
 
 export const validateOutput = (
     output: any,
-    request: WriteRequest & { operation: { outputSchema: ZodSchema } },
+    request: WriteRequest & { operation: { outputSchema: ZodType } },
 ) => {
     const parseRes = request.operation.outputSchema.safeParse(output)
     if (!parseRes.success) {

--- a/packages/roc-db/src/readOperation.ts
+++ b/packages/roc-db/src/readOperation.ts
@@ -1,4 +1,4 @@
-import type { z, ZodSchema, ZodType } from "zod"
+import type { z, ZodType } from "zod"
 import type { ReadOperation } from "./types/ReadOperation"
 import type { ReadTransaction } from "./lib/ReadTransaction"
 import type { ReadRequest } from "./types/ReadRequest"
@@ -6,7 +6,7 @@ import type { Ref } from "./types/Ref"
 
 export const readOperation = <
     const Name extends string,
-    const PayloadSchema extends ZodSchema,
+    const PayloadSchema extends ZodType,
 >(
     name: Name,
     payloadSchema: PayloadSchema,

--- a/packages/roc-db/src/schemas/generators/mutationSchemaGenerator.ts
+++ b/packages/roc-db/src/schemas/generators/mutationSchemaGenerator.ts
@@ -1,11 +1,11 @@
-import { z, ZodSchema, ZodType } from "zod"
+import { z, ZodType } from "zod"
 import { RefSchema } from "../RefSchema"
 import { MutationSchema } from "../MutationSchema"
 import { MutationLogSchema } from "../MutationLogSchema"
 
 export const mutationSchemaGenerator = <
     const Name extends string,
-    Payload extends ZodSchema,
+    Payload extends ZodType,
 >(
     name: Name,
     payloadSchema: Payload,

--- a/packages/roc-db/src/types/Adapter.ts
+++ b/packages/roc-db/src/types/Adapter.ts
@@ -1,1 +1,35 @@
-export type Adapter = any
+import type { z, ZodType } from "zod"
+import type { Mutation } from "./Mutation"
+import type { Operation } from "./Operation"
+import type { Ref } from "./Ref"
+
+type OperationMethod<Op extends Operation> = Op extends {
+    type: "write"
+    payloadSchema: infer P extends ZodType
+}
+    ? (payload: z.input<P>) => [any, Mutation]
+    : Op extends { payloadSchema: infer P extends ZodType }
+      ? (payload: z.input<P>) => any
+      : never
+
+type OperationMethods<Operations extends readonly Operation[]> = {
+    [Item in Operations[number] as Item["name"]]: OperationMethod<Item>
+}
+
+export type Adapter<
+    Operations extends readonly Operation[] = readonly Operation[],
+    EngineOptions extends {} = {},
+> = {
+    readonly _name: string
+    readonly _engineOpts: EngineOptions
+    readonly _adapterOpts: any
+    readonly _entityKinds: string[]
+    readonly _operationNames: string[]
+    readonly _operations: readonly Operation[]
+    readonly _entities: readonly any[]
+    clone: (overrides?: Partial<EngineOptions>) => Adapter<Operations, EngineOptions>
+    generateRef: (entity: string) => Ref
+    changeSet: (changeSetRef: Ref) => Adapter<Operations, EngineOptions>
+    loadMutations?: (mutations: Mutation[]) => any
+    persistOptimisticMutations?: (mutations: Mutation[]) => Mutation[]
+} & OperationMethods<Operations>

--- a/packages/roc-db/src/types/ReadOperation.ts
+++ b/packages/roc-db/src/types/ReadOperation.ts
@@ -1,9 +1,9 @@
-import type { ZodSchema } from "zod"
+import type { ZodType } from "zod"
 
 export type ReadOperation<
     Name extends string = string,
-    PayloadSchema extends ZodSchema = ZodSchema,
-    OutputSchema extends ZodSchema = ZodSchema,
+    PayloadSchema extends ZodType = ZodType,
+    OutputSchema extends ZodType = ZodType,
 > = {
     readonly type: "read"
     readonly name: Name

--- a/packages/roc-db/src/types/WriteOperation.ts
+++ b/packages/roc-db/src/types/WriteOperation.ts
@@ -1,16 +1,16 @@
-import type { z, ZodSchema } from "zod"
+import type { z, ZodType } from "zod"
 
 export type WriteOperation<
     Name extends string = string,
-    PayloadSchema extends ZodSchema = ZodSchema,
+    PayloadSchema extends ZodType = ZodType,
 > = {
     readonly type: "write"
     readonly name: Name
     readonly payloadSchema: PayloadSchema
-    readonly outputSchema?: ZodSchema
+    readonly outputSchema?: ZodType
     readonly version: number
     readonly debounce: number
     readonly changeSetOnly: boolean
     readonly callback: (payload: z.output<PayloadSchema>) => any
-    readonly mutationSchema: ZodSchema
+    readonly mutationSchema: ZodType
 }

--- a/packages/roc-db/src/types/WriteOperationSettings.ts
+++ b/packages/roc-db/src/types/WriteOperationSettings.ts
@@ -1,9 +1,9 @@
-import type { ZodSchema } from "zod"
+import type { ZodType } from "zod"
 
 export type WriteOperationSettings = {
     version?: number
     debounce?: number
     changeSetOnly?: boolean
-    outputSchema?: ZodSchema
-    mutationLogSchema?: ZodSchema
+    outputSchema?: ZodType
+    mutationLogSchema?: ZodType
 }

--- a/packages/roc-db/src/types/WriteRequest.ts
+++ b/packages/roc-db/src/types/WriteRequest.ts
@@ -1,9 +1,9 @@
-import type { ZodSchema } from "zod"
+import type { ZodType } from "zod"
 import type { Mutation } from "./Mutation"
 import type { Ref } from "./Ref"
 import type { WriteOperation } from "./WriteOperation"
 
-export type WriteRequest<PayloadSchema extends ZodSchema = ZodSchema> = {
+export type WriteRequest<PayloadSchema extends ZodType = ZodType> = {
     type: "write"
     operation: WriteOperation
     payload: any

--- a/packages/roc-db/src/writeOperation.ts
+++ b/packages/roc-db/src/writeOperation.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema } from "zod"
+import { z, ZodType } from "zod"
 import { WriteTransaction } from "./lib/WriteTransaction"
 import { mutationSchemaGenerator } from "./schemas/generators/mutationSchemaGenerator"
 import type { WriteOperation } from "./types/WriteOperation"
@@ -6,7 +6,7 @@ import type { WriteOperationSettings } from "./types/WriteOperationSettings"
 
 export const writeOperation = <
     const Name extends string = string,
-    PayloadSchema extends ZodSchema = ZodSchema,
+    PayloadSchema extends ZodType = ZodType,
 >(
     name: Name,
     payloadSchema: PayloadSchema,


### PR DESCRIPTION
- Improve typing on createAdapter so it returns typing on the adapter with all operations.
- Replace all occurences of the depracted `ZodSchema` with `ZodType`  