### PR TITLE
Add type-safe generics to transactions and query system

### DIFF
--- a/packages/roc-db/src/Entity.ts
+++ b/packages/roc-db/src/Entity.ts
@@ -31,8 +31,8 @@ type EntitySchemaOutput<
 > = {
     ref: `${Name}/${number}`
     entity: Name
-    created: { timestamp: Date; mutationRef: MutationRef }
-    updated: { timestamp: Date; mutationRef: MutationRef }
+    created: { timestamp: string; mutationRef: MutationRef }
+    updated: { timestamp: string; mutationRef: MutationRef }
     data: z.output<Data>
     children: z.output<Children>
     parents: z.output<Parents>

--- a/packages/roc-db/src/Entity.ts
+++ b/packages/roc-db/src/Entity.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema, type ZodObject } from "zod"
+import { z, type ZodObject } from "zod"
 import { refSchemaGenerator } from "./schemas/generators/refSchemaGenerator"
 import { TimestampWithMutationRefSchema } from "./schemas/TimestampWithMutationRefSchema"
 
@@ -20,6 +20,25 @@ const addUndefinedCheck = schema => {
     })
 }
 
+type MutationRef = `Mutation/${number}`
+
+type EntitySchemaOutput<
+    Name extends string,
+    Data extends ZodObject<any>,
+    Children extends ZodObject<any>,
+    Parents extends ZodObject<any>,
+    Ancestors extends ZodObject<any>,
+> = {
+    ref: `${Name}/${number}`
+    entity: Name
+    created: { timestamp: Date; mutationRef: MutationRef }
+    updated: { timestamp: Date; mutationRef: MutationRef }
+    data: z.output<Data>
+    children: z.output<Children>
+    parents: z.output<Parents>
+    ancestors: z.output<Ancestors>
+}
+
 export class Entity<
     const Name extends string,
     const Data extends ZodObject<any> = ZodObject<{}>,
@@ -30,31 +49,11 @@ export class Entity<
     name: Name
     indexedDataKeys: string[]
     uniqueDataKeys: string[]
-    schema: ZodObject<{
-        ref: z.ZodType<`${Name}/${string}`, z.ZodTypeDef, `${Name}/${string}`>
-        entity: z.ZodLiteral<Name>
-        created: z.ZodObject<{
-            timestamp: z.ZodDate
-            mutationRef: z.ZodType<
-                `${Name}/${string}`,
-                z.ZodTypeDef,
-                `${Name}/${string}`
-            >
-        }>
-        updated: z.ZodObject<{
-            timestamp: z.ZodDate
-            mutationRef: z.ZodType<
-                `${Name}/${string}`,
-                z.ZodTypeDef,
-                `${Name}/${string}`
-            >
-        }>
-        data: Data
-        children: Children
-        parents: Parents
-        ancestors: Ancestors
-    }>
-    refSchema: z.ZodType<`${Name}/${string}`, z.ZodTypeDef, `${Name}/${string}`>
+    schema: z.ZodType<
+        EntitySchemaOutput<Name, Data, Children, Parents, Ancestors>,
+        EntitySchemaOutput<Name, Data, Children, Parents, Ancestors>
+    >
+    refSchema: z.ZodType<`${Name}/${number}`, `${Name}/${number}`>
     constructor(
         name: Name,
         args: {
@@ -69,7 +68,7 @@ export class Entity<
         this.name = name
         this.indexedDataKeys = args.indexedDataKeys ?? []
         this.uniqueDataKeys = args.uniqueDataKeys ?? []
-        this.refSchema = refSchemaGenerator(name)
+        this.refSchema = refSchemaGenerator(name) as any
         this.schema = z
             .object({
                 ref: this.refSchema,
@@ -90,6 +89,6 @@ export class Entity<
                 ) as Ancestors,
             })
             .strict()
-            .required()
+            .required() as any
     }
 }

--- a/packages/roc-db/src/errors/NotFoundError.ts
+++ b/packages/roc-db/src/errors/NotFoundError.ts
@@ -1,4 +1,4 @@
-import { Ref } from "../types/Ref"
+import type { Ref } from "../types/Ref"
 
 export class NotFoundError extends Error {
     constructor(ref: Ref) {

--- a/packages/roc-db/src/index.ts
+++ b/packages/roc-db/src/index.ts
@@ -21,6 +21,7 @@ export { refSchemaGenerator } from "./schemas/generators/refSchemaGenerator"
 // types
 export type { ReadTransaction } from "./lib/ReadTransaction"
 // export type { WriteTransaction } from "./lib/WriteTransaction"
+export type { ReadEntityResult } from "./types/ReadEntityResult"
 export type { Adapter } from "./types/Adapter"
 export type {
     AdapterFunctions,
@@ -49,6 +50,7 @@ export { parseRef } from "./utils/parseRef"
 export { Query } from "./utils/Query"
 export { QueryArray } from "./utils/QueryArray"
 export { QueryChain } from "./utils/QueryChain"
+export { QueryChainClass } from "./utils/QueryChainClass"
 export { QueryObject } from "./utils/QueryObject"
 export { refsFromRelations } from "./utils/refsFromRelations"
 export { Snowflake } from "./utils/Snowflake"

--- a/packages/roc-db/src/lib/ReadTransaction.ts
+++ b/packages/roc-db/src/lib/ReadTransaction.ts
@@ -1,5 +1,6 @@
 import { BadRequestError } from "../errors/BadRequestError"
 import type { AdapterOptions } from "../types/AdapterOptions"
+import type { ReadEntityResult } from "../types/ReadEntityResult"
 import type { Ref } from "../types/Ref"
 import type { RocDBRequest } from "../types/RocDBRequest"
 import { refsFromRelations } from "../utils/refsFromRelations"
@@ -17,13 +18,13 @@ type ChangeSetCache = {
     initialized: boolean
 }
 
-export class ReadTransaction<EngineOpts extends any = any> {
+export class ReadTransaction<EngineOpts extends any = any, Payload = any> {
     changeSetRef: Ref | null
     constructor(
         public request: RocDBRequest,
         public engineOpts: EngineOpts,
         public adapter: AdapterOptions<EngineOpts>,
-        public payload: any,
+        public payload: Payload,
         public changeSet: ChangeSetCache,
     ) {
         this.request = request
@@ -42,7 +43,8 @@ export class ReadTransaction<EngineOpts extends any = any> {
         }
     }
 
-    batchReadEntities = (refs: Ref[]) => batchReadEntities(this, refs)
+    batchReadEntities = <R extends Ref>(refs: R[]): ReadEntityResult<R>[] =>
+        batchReadEntities(this, refs) as ReadEntityResult<R>[]
 
     getChangeSetMutations = (ref: Ref) => {
         if (!ref)
@@ -52,8 +54,8 @@ export class ReadTransaction<EngineOpts extends any = any> {
         return this.adapter.functions.getChangeSetMutations(this, ref)
     }
 
-    readEntity = (ref: Ref, throwIfNotFound = true) =>
-        readEntity(this, ref, throwIfNotFound)
+    readEntity = <R extends Ref>(ref: R, throwIfNotFound = true): ReadEntityResult<R> =>
+        readEntity(this, ref, throwIfNotFound) as ReadEntityResult<R>
 
     readEntityByUniqueField = (entity, field, value, throwIfNotFound = true) =>
         readEntityByUniqueField(this, entity, field, value, throwIfNotFound)

--- a/packages/roc-db/src/lib/WriteTransaction.ts
+++ b/packages/roc-db/src/lib/WriteTransaction.ts
@@ -2,6 +2,7 @@ import type { AdapterOptions } from "../types/AdapterOptions"
 import type { Entity } from "../types/Entity"
 import type { Mutation } from "../types/Mutation"
 import type { MutationRef } from "../types/MutationRef"
+import type { ReadEntityResult } from "../types/ReadEntityResult"
 import type { Ref } from "../types/Ref"
 import type { RocDBRequest } from "../types/RocDBRequest"
 import { ReadTransaction } from "./ReadTransaction"
@@ -26,7 +27,8 @@ type Log = Map<Ref, LogItem>
 
 export class WriteTransaction<
     EngineOpts extends any = any,
-> extends ReadTransaction<EngineOpts> {
+    Payload = any,
+> extends ReadTransaction<EngineOpts, Payload> {
     mutationFinalized: boolean
     optimisticCreateRefs: string[]
     log: Log
@@ -35,7 +37,7 @@ export class WriteTransaction<
         public request: RocDBRequest,
         public engineOpts: EngineOpts,
         public adapter: AdapterOptions<EngineOpts>,
-        public payload: RocDBRequest["payload"],
+        public payload: Payload,
         public mutation: Mutation,
         public optimisticRefs: [string, string, string][] = [],
         changeSet: any = undefined,
@@ -53,8 +55,9 @@ export class WriteTransaction<
 
     applyChangeSet = (ref: Ref) => applyChangeSet(this, ref)
     commit = (isChangeSetApply = false) => commit(this, isChangeSetApply)
-    createEntity = (ref: Ref, body: any) => createEntity(this, ref, body)
-    createRef = (entity: string) => createRef(this, entity)
+    createEntity = <R extends Ref>(ref: R, body: any): ReadEntityResult<R> =>
+        createEntity(this, ref, body) as ReadEntityResult<R>
+    createRef = <E extends string>(entity: E) => createRef(this, entity)
     deleteEntity = (ref: Ref, cascade = false) =>
         deleteEntity(this, ref, cascade)
     deleteChangeSet = (changeSetRef: Ref) => deleteChangeSet(this, changeSetRef)
@@ -66,8 +69,8 @@ export class WriteTransaction<
     }
     findDependents = (ref: Ref) => findDependents(this, ref)
     patchEntity = (ref: Ref, args: any) => patchEntity(this, ref, args)
-    readEntity = (ref: Ref, throwIfMissing = true) =>
-        readEntity(this, ref, throwIfMissing)
+    readEntity = <R extends Ref>(ref: R, throwIfMissing = true): ReadEntityResult<R> =>
+        readEntity(this, ref, throwIfMissing) as ReadEntityResult<R>
     undo = (mutationRef: MutationRef) => undo(this, mutationRef)
     updateEntity = (ref: Ref, body: any) => updateEntity(this, ref, body)
 }

--- a/packages/roc-db/src/lib/createRef.ts
+++ b/packages/roc-db/src/lib/createRef.ts
@@ -3,7 +3,7 @@ import { entityFromRef } from "../utils/entityFromRef"
 import { generateRef } from "../utils/generateRef"
 import type { WriteTransaction } from "./WriteTransaction"
 
-export const createRef = (txn: WriteTransaction, entity: string): Ref => {
+export const createRef = <E extends string>(txn: WriteTransaction, entity: E): `${E}/${number}` => {
     if (txn.optimisticRefs.length) {
         const nextRef = txn.optimisticCreateRefs.shift()
         if (!nextRef) throw new Error("No next ref")
@@ -17,7 +17,7 @@ export const createRef = (txn: WriteTransaction, entity: string): Ref => {
             )
         }
         txn.log.set(nextRef, ["ref"])
-        return nextRef as Ref
+        return nextRef as `${E}/${number}`
     }
 
     const ref = generateRef(
@@ -26,5 +26,5 @@ export const createRef = (txn: WriteTransaction, entity: string): Ref => {
         txn.mutation.timestamp,
     )
     txn.log.set(ref, ["ref"])
-    return ref as Ref
+    return ref as `${E}/${number}`
 }

--- a/packages/roc-db/src/readOperation.ts
+++ b/packages/roc-db/src/readOperation.ts
@@ -1,8 +1,6 @@
-import type { z, ZodSchema, ZodType } from "zod"
+import type { z, ZodSchema } from "zod"
 import type { ReadOperation } from "./types/ReadOperation"
 import type { ReadTransaction } from "./lib/ReadTransaction"
-import type { ReadRequest } from "./types/ReadRequest"
-import type { Ref } from "./types/Ref"
 
 export const readOperation = <
     const Name extends string,
@@ -10,30 +8,12 @@ export const readOperation = <
 >(
     name: Name,
     payloadSchema: PayloadSchema,
-    callback: (
-        txn: ReadTransaction<ReadRequest<z.infer<InputSchema>>, any, any, any>,
-    ) => ZodType<OutputSchema>,
-): ReadOperation<Name, ZodType<InputSchema>, ZodType<OutputSchema>> => {
+    callback: (txn: ReadTransaction<any, z.output<PayloadSchema>>) => any,
+): ReadOperation<Name, PayloadSchema> => {
     return {
         type: "read",
         name,
         payloadSchema,
         callback,
-    }
-    // return Object.assign(
-    //     (payload: ZodType<InputSchema>, changeSetRef?: Ref) => {
-    //         return {
-    //             type: "read",
-    //             schema: inputSchema,
-    //             payload,
-    //             callback: queryFn,
-    //             changeSetRef,
-    //             operationName,
-    //         } as const
-    //     },
-    //     {
-    //         operationName: operationName,
-    //         outputSchema: outputSchema,
-    //     },
-    // )
+    } as ReadOperation<Name, PayloadSchema>
 }

--- a/packages/roc-db/src/schemas/generators/entitySchemaGeneratorDebug.ts
+++ b/packages/roc-db/src/schemas/generators/entitySchemaGeneratorDebug.ts
@@ -1,4 +1,4 @@
-import { z, ZodObject } from "zod"
+import { z, type ZodObject } from "zod"
 import { EntitySchema } from "../EntitySchema"
 import { refSchemaGenerator } from "./refSchemaGenerator"
 

--- a/packages/roc-db/src/schemas/generators/mutationSchemaGenerator.ts
+++ b/packages/roc-db/src/schemas/generators/mutationSchemaGenerator.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema, ZodType } from "zod"
+import { z, type ZodSchema, type ZodType } from "zod"
 import { RefSchema } from "../RefSchema"
 import { MutationSchema } from "../MutationSchema"
 import { MutationLogSchema } from "../MutationLogSchema"

--- a/packages/roc-db/src/types/AdapterOptions.ts
+++ b/packages/roc-db/src/types/AdapterOptions.ts
@@ -5,4 +5,7 @@ export type AdapterOptions<EngineOpts extends any = any> = {
     functions: AdapterFunctions<EngineOpts>
     async: boolean
     operations: WriteOperation[]
+    session: any
+    snowflake: any
+    [key: string]: any
 }

--- a/packages/roc-db/src/types/Mutation.ts
+++ b/packages/roc-db/src/types/Mutation.ts
@@ -1,6 +1,5 @@
-import { z } from "zod"
-import { MutationRef } from "./MutationRef"
-import { Ref } from "./Ref"
+import type { MutationRef } from "./MutationRef"
+import type { Ref } from "./Ref"
 
 export type Mutation = {
     ref: MutationRef

--- a/packages/roc-db/src/types/ReadEntityResult.ts
+++ b/packages/roc-db/src/types/ReadEntityResult.ts
@@ -1,0 +1,20 @@
+import type { Ref } from "./Ref"
+
+type EntityNameFromRef<R extends Ref> = R extends `${infer E}/${string}` ? E : never
+
+type BaseEntity = {
+    ref: Ref
+    entity: string
+    data: Record<string, any>
+    parents: Record<string, Ref>
+    children: Record<string, Ref[]>
+    ancestors: Record<string, Ref>
+    created: { timestamp: string; mutationRef: Ref }
+    updated: { timestamp: string; mutationRef: Ref }
+    [key: string]: unknown
+}
+
+export type ReadEntityResult<R extends Ref> =
+    EntityNameFromRef<R> extends keyof RocDBEntityRegistry
+        ? RocDBEntityRegistry[EntityNameFromRef<R>]
+        : BaseEntity

--- a/packages/roc-db/src/utils/Query.ts
+++ b/packages/roc-db/src/utils/Query.ts
@@ -3,15 +3,18 @@ import { QueryChainClass } from "./QueryChainClass"
 import { QueryClass } from "./QueryClass"
 import type { QueryObjectClass } from "./QueryObjectClass"
 
-export const Query = <I extends any[], O>(
-    fn: (
-        ...args: I
-    ) =>
-        | O
-        | QueryClass<any[], O>
-        | QueryChainClass<O>
-        | QueryObjectClass<O & Record<string, unknown>>
-        | QueryArrayClass<O>,
-): QueryClass<I, O> => {
-    return new QueryClass(fn as (...args: I) => O | QueryChainClass<O>)
+type UnwrapReturnType<T> = T extends QueryClass<any[], infer O>
+    ? O
+    : T extends QueryChainClass<infer O>
+      ? O
+      : T extends QueryObjectClass<infer O>
+        ? O
+        : T extends QueryArrayClass<infer O>
+          ? O
+          : T
+
+export const Query = <I extends any[], R>(
+    fn: (...args: I) => R,
+): QueryClass<I, UnwrapReturnType<R>> => {
+    return new QueryClass(fn as (...args: I) => UnwrapReturnType<R> | QueryChainClass<UnwrapReturnType<R>>)
 }

--- a/packages/roc-db/src/utils/Query.ts
+++ b/packages/roc-db/src/utils/Query.ts
@@ -1,8 +1,17 @@
+import type { QueryArrayClass } from "./QueryArrayClass"
 import { QueryChainClass } from "./QueryChainClass"
 import { QueryClass } from "./QueryClass"
+import type { QueryObjectClass } from "./QueryObjectClass"
 
 export const Query = <I extends any[], O>(
-    fn: (...args: I) => O | QueryChainClass<O>,
+    fn: (
+        ...args: I
+    ) =>
+        | O
+        | QueryClass<any[], O>
+        | QueryChainClass<O>
+        | QueryObjectClass<O & Record<string, unknown>>
+        | QueryArrayClass<O>,
 ): QueryClass<I, O> => {
-    return new QueryClass(fn)
+    return new QueryClass(fn as (...args: I) => O | QueryChainClass<O>)
 }

--- a/packages/roc-db/src/utils/QueryArray.ts
+++ b/packages/roc-db/src/utils/QueryArray.ts
@@ -2,12 +2,20 @@ import { QueryArrayClass } from "./QueryArrayClass"
 import type { QueryChainClass } from "./QueryChainClass"
 import type { QueryClass } from "./QueryClass"
 
+type UnwrapQueryResult<T> = T extends QueryChainClass<infer O>
+    ? O
+    : T extends QueryClass<any, infer O>
+      ? O
+      : T extends QueryArrayClass<infer O>
+        ? O
+        : unknown
+
 export type QueryArrayType = (
     | QueryChainClass<any>
     | QueryClass<any, any>
     | QueryArrayClass
 )[]
 
-export const QueryArray = (arr: QueryArrayType) => {
-    return new QueryArrayClass(arr)
+export const QueryArray = <T extends QueryArrayType>(arr: T): QueryArrayClass<UnwrapQueryResult<T[number]>[]> => {
+    return new QueryArrayClass(arr) as QueryArrayClass<UnwrapQueryResult<T[number]>[]>
 }

--- a/packages/roc-db/src/utils/QueryArrayClass.ts
+++ b/packages/roc-db/src/utils/QueryArrayClass.ts
@@ -1,7 +1,7 @@
 import type { QueryArrayType } from "./QueryArray"
 import { QueryBaseClass } from "./QueryBaseClass"
 
-export class QueryArrayClass extends QueryBaseClass {
+export class QueryArrayClass<T = unknown> extends QueryBaseClass {
     array: QueryArrayType
     constructor(array: QueryArrayType) {
         super()

--- a/packages/roc-db/src/utils/QueryChain.ts
+++ b/packages/roc-db/src/utils/QueryChain.ts
@@ -1,65 +1,189 @@
+import type { QueryArrayClass } from "./QueryArrayClass"
 import { QueryChainClass } from "./QueryChainClass"
 import { QueryClass } from "./QueryClass"
+import type { QueryObjectClass } from "./QueryObjectClass"
+
+type AnyQuery<I extends any[], O> =
+    | QueryClass<I, O>
+    | QueryChainClass<O>
+    | QueryObjectClass<O & Record<string, unknown>>
+    | QueryArrayClass<O>
+    | undefined
+
+type UnwrapOutput<O> = O extends QueryClass<any[], infer T>
+    ? T
+    : O extends QueryObjectClass<infer T>
+      ? T
+      : O extends QueryArrayClass<infer T>
+        ? T
+        : O extends QueryChainClass<infer T>
+          ? T
+          : O
 
 type QueryChainFn = {
     // 1 query
-    <O1>(q1: QueryClass<[], O1>): QueryChainClass<O1>
+    <O1>(q1: AnyQuery<[], O1>): QueryChainClass<UnwrapOutput<O1>>
     // 2 queries
     <O1, O2>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-    ): QueryChainClass<O2>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+    ): QueryChainClass<UnwrapOutput<O2>>
     // 3 queries
     <O1, O2, O3>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-    ): QueryChainClass<O3>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+    ): QueryChainClass<UnwrapOutput<O3>>
     // 4 queries
     <O1, O2, O3, O4>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-        q4: QueryClass<[O3, O2, O1], O4>,
-    ): QueryChainClass<O4>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+        q4: AnyQuery<
+            [UnwrapOutput<O3>, UnwrapOutput<O2>, UnwrapOutput<O1>],
+            O4
+        >,
+    ): QueryChainClass<UnwrapOutput<O4>>
     // 5 queries
     <O1, O2, O3, O4, O5>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-        q4: QueryClass<[O3, O2, O1], O4>,
-        q5: QueryClass<[O4, O3, O2, O1], O5>,
-    ): QueryChainClass<O5>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+        q4: AnyQuery<
+            [UnwrapOutput<O3>, UnwrapOutput<O2>, UnwrapOutput<O1>],
+            O4
+        >,
+        q5: AnyQuery<
+            [
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O5
+        >,
+    ): QueryChainClass<UnwrapOutput<O5>>
     // 6 queries
     <O1, O2, O3, O4, O5, O6>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-        q4: QueryClass<[O3, O2, O1], O4>,
-        q5: QueryClass<[O4, O3, O2, O1], O5>,
-        q6: QueryClass<[O6, O4, O3, O2, O1], O6>,
-    ): QueryChainClass<O6>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+        q4: AnyQuery<
+            [UnwrapOutput<O3>, UnwrapOutput<O2>, UnwrapOutput<O1>],
+            O4
+        >,
+        q5: AnyQuery<
+            [
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O5
+        >,
+        q6: AnyQuery<
+            [
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O6
+        >,
+    ): QueryChainClass<UnwrapOutput<O6>>
     // 7 queries
     <O1, O2, O3, O4, O5, O6, O7>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-        q4: QueryClass<[O3, O2, O1], O4>,
-        q5: QueryClass<[O4, O3, O2, O1], O5>,
-        q6: QueryClass<[O5, O4, O3, O2, O1], O6>,
-        q7: QueryClass<[O6, O5, O4, O3, O2, O1], O7>,
-    ): QueryChainClass<O7>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+        q4: AnyQuery<
+            [UnwrapOutput<O3>, UnwrapOutput<O2>, UnwrapOutput<O1>],
+            O4
+        >,
+        q5: AnyQuery<
+            [
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O5
+        >,
+        q6: AnyQuery<
+            [
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O6
+        >,
+        q7: AnyQuery<
+            [
+                UnwrapOutput<O6>,
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O7
+        >,
+    ): QueryChainClass<UnwrapOutput<O7>>
     // 8 queries
     <O1, O2, O3, O4, O5, O6, O7, O8>(
-        q1: QueryClass<[], O1>,
-        q2: QueryClass<[O1], O2>,
-        q3: QueryClass<[O2, O1], O3>,
-        q4: QueryClass<[O3, O2, O1], O4>,
-        q5: QueryClass<[O4, O3, O2, O1], O5>,
-        q6: QueryClass<[O5, O4, O3, O2, O1], O6>,
-        q7: QueryClass<[O6, O5, O4, O3, O2, O1], O7>,
-        q8: QueryClass<[O7, O6, O5, O4, O3, O2, O1], O8>,
-    ): QueryChainClass<O8>
+        q1: AnyQuery<[], O1>,
+        q2: AnyQuery<[UnwrapOutput<O1>], O2>,
+        q3: AnyQuery<[UnwrapOutput<O2>, UnwrapOutput<O1>], O3>,
+        q4: AnyQuery<
+            [UnwrapOutput<O3>, UnwrapOutput<O2>, UnwrapOutput<O1>],
+            O4
+        >,
+        q5: AnyQuery<
+            [
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O5
+        >,
+        q6: AnyQuery<
+            [
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O6
+        >,
+        q7: AnyQuery<
+            [
+                UnwrapOutput<O6>,
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O7
+        >,
+        q8: AnyQuery<
+            [
+                UnwrapOutput<O7>,
+                UnwrapOutput<O6>,
+                UnwrapOutput<O5>,
+                UnwrapOutput<O4>,
+                UnwrapOutput<O3>,
+                UnwrapOutput<O2>,
+                UnwrapOutput<O1>,
+            ],
+            O8
+        >,
+    ): QueryChainClass<UnwrapOutput<O8>>
 }
 
 export const QueryChain: QueryChainFn = (

--- a/packages/roc-db/src/utils/QueryObject.ts
+++ b/packages/roc-db/src/utils/QueryObject.ts
@@ -11,6 +11,20 @@ type JSON =
     | { [property in string]: JSON }
     | JSON[]
 
+type UnwrapQueryValue<T> = T extends QueryChainClass<infer O>
+    ? O
+    : T extends QueryClass<any, infer O>
+      ? O
+      : T extends QueryObjectClass<infer O>
+        ? O
+        : T extends QueryArrayClass<infer O>
+          ? O
+          : T
+
+type UnwrapQueryMap<T extends Record<string, unknown>> = {
+    [K in keyof T]: UnwrapQueryValue<T[K]>
+}
+
 type QueryMapObject = {
     [key: string]:
         | QueryChainClass<any>
@@ -18,10 +32,8 @@ type QueryMapObject = {
         | QueryArrayClass
         | QueryObjectClass
         | JSON
-    // | QueryArray<any>
-    // | JSON
 }
 
-export const QueryObject = (obj: QueryMapObject) => {
-    return new QueryObjectClass(obj)
+export const QueryObject = <T extends Record<string, unknown>>(obj: T) => {
+    return new QueryObjectClass<UnwrapQueryMap<T>>(obj as any)
 }

--- a/packages/roc-db/src/utils/QueryObjectClass.ts
+++ b/packages/roc-db/src/utils/QueryObjectClass.ts
@@ -2,9 +2,7 @@ import { QueryBaseClass } from "./QueryBaseClass";
 import type { QueryChainClass } from "./QueryChainClass";
 import type { QueryClass } from "./QueryClass";
 
-type QueryMapObject = { [key: string]: QueryChainClass<any> | QueryClass<any, any>; }
-
-export class QueryObjectClass extends QueryBaseClass {
+export class QueryObjectClass<T extends Record<string, unknown> = Record<string, unknown>> extends QueryBaseClass {
     map: { [key: string]: QueryChainClass<any> | QueryClass<any, any>; };
     constructor(map: {
         [key: string]: QueryChainClass<any> | QueryClass<any, any>;

--- a/packages/roc-db/src/writeOperation.ts
+++ b/packages/roc-db/src/writeOperation.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema } from "zod"
+import { z, type ZodSchema } from "zod"
 import { WriteTransaction } from "./lib/WriteTransaction"
 import { mutationSchemaGenerator } from "./schemas/generators/mutationSchemaGenerator"
 import type { WriteOperation } from "./types/WriteOperation"

--- a/packages/roc-db/src/writeOperation.ts
+++ b/packages/roc-db/src/writeOperation.ts
@@ -10,7 +10,7 @@ export const writeOperation = <
 >(
     name: Name,
     payloadSchema: PayloadSchema,
-    callback: (txn: WriteTransaction) => any,
+    callback: (txn: WriteTransaction<any, z.output<PayloadSchema>>) => any,
     settings: WriteOperationSettings = {},
 ): WriteOperation<Name, PayloadSchema> => {
     const {


### PR DESCRIPTION
## Summary

RocDB operations return `any` or `unknown` for entity reads, creates, and query chains. This makes it impossible for consumers like ShiftX to get proper type inference through their operation pipelines — every `txn.readEntity(ref)` or `txn.createEntity(ref, body)` returns untyped results, requiring manual casts or losing type safety entirely.

This PR adds generic type parameters throughout the query and transaction system so types flow correctly from entity schemas to operation results.

### Key changes

- **Fix Zod 4 compatibility in Entity.ts**: The old `z.ZodTypeDef` type was removed in Zod 4, causing `ref: unknown` on all entity types. Replaced with an explicit `EntitySchemaOutput` type that correctly types all entity fields including `ref: \`${Name}/${number}\``
- **Fix EntitySchemaOutput timestamp type**: `created.timestamp` and `updated.timestamp` were incorrectly typed as `Date` but `TimestampWithMutationRefSchema` uses `z.string().datetime()` which infers as `string`. Fixed to `string` to match the actual schema and runtime values.
- **Generic transactions**: `ReadTransaction` and `WriteTransaction` gain a `Payload` generic. `readEntity<R>`, `createEntity<R>`, and `batchReadEntities<R>` return `ReadEntityResult<R>` which resolves to the correct entity type via the consumer's `RocDBEntityRegistry`
- **Generic `createRef`**: Returns `` `${E}/${number}` `` instead of `Ref`, preserving the entity name in the type
- **Typed operation payloads**: `writeOperation` and `readOperation` pass `z.output<PayloadSchema>` as the `Payload` generic, so `txn.payload` is properly typed
- **Polymorphic QueryChain**: Accepts `AnyQuery` union (QueryClass, QueryChainClass, QueryObjectClass, QueryArrayClass, undefined) with `UnwrapOutput` to extract result types — previously only accepted `QueryClass`
- **Generic QueryArray/QueryObject**: Infer and preserve inner query result types through `UnwrapQueryResult` and `UnwrapQueryMap`
- **Fix Query type inference for union return types**: When a `Query` callback has if/else branches returning different types, the inferred type now correctly produces the union via `UnwrapReturnType<R>` instead of locking to the first branch
- **Fix type-only imports for Vite compatibility**: `Ref`, `ZodSchema`, `ZodType`, `ZodObject` are type-only exports in their respective modules — changed to `import type` to prevent Vite runtime errors
- **AdapterOptions**: Add `session`, `snowflake`, and index signature for adapter-specific properties

### How `ReadEntityResult<R>` works

Consumers declare a global registry mapping entity names to types:

```typescript
declare global {
    interface RocDBEntityRegistry {
        Process: Process
        ProcessStep: ProcessStep
        // ...
    }
}
```

Then `txn.readEntity(processRef)` where `processRef: \`Process/${number}\`` automatically returns `Process` instead of `any`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)