### PR TITLE
Fix sortMutations dropping causal order for mixed-persistence changeSets

### DIFF
--- a/packages/roc-db/src/lib/applyChangeSet.test.ts
+++ b/packages/roc-db/src/lib/applyChangeSet.test.ts
@@ -64,4 +64,56 @@ describe("applyChangeSet", () => {
         expect(readPostBefore.children.blocks).toHaveLength(0)
         expect(readPostAfter.children.blocks).toHaveLength(1)
     })
+
+    test("replays mutations in creation order when changeSet mixes persisted and not-yet-persisted mutations", () => {
+        // Scenario: a changeSet contains three mutations where the middle one
+        // never got `persistedAt` set (e.g. applyChangeSet runs while the
+        // client is offline or before that mutation's sync round-trip lands).
+        //   1. createBlockRow   — persisted
+        //   2. createBlockParagraph (child of row) — NOT persisted
+        //   3. deleteBlocks([row]) — persisted
+        //
+        // If sort puts persisted ahead of unpersisted, deleteBlocks runs
+        // before the paragraph create and the paragraph's readEntity(rowRef)
+        // throws "Entity not found".
+        const engine = {
+            entities: new Map(),
+            mutations: new Map(),
+            entitiesUnique: new Map(),
+            entitiesIndex: new Map(),
+        }
+        const adapter = createInMemoryAdapter({
+            operations: [...operations, applyDraftTest],
+            entities,
+            session: { identityRef: "User/42" },
+            snowflake,
+            engine,
+        })
+
+        const [post] = adapter.createPost({ title: "Post 1" })
+        const [draft] = adapter.createDraft({ postRef: post.ref })
+
+        const draftAdapter = adapter.changeSet(draft.ref)
+
+        const [{ block: row }, rowMutation] = draftAdapter.createBlockRow({
+            parentRef: post.ref,
+        })
+        engine.mutations.set(rowMutation.ref, {
+            ...engine.mutations.get(rowMutation.ref),
+            persistedAt: rowMutation.timestamp,
+        })
+
+        draftAdapter.createBlockParagraph({
+            parentRef: row.ref,
+            content: "Hello world",
+        })
+
+        const [, deleteMutation] = draftAdapter.deleteBlocks([row.ref])
+        engine.mutations.set(deleteMutation.ref, {
+            ...engine.mutations.get(deleteMutation.ref),
+            persistedAt: deleteMutation.timestamp,
+        })
+
+        expect(() => adapter.applyDraftTest(draft.ref)).not.toThrow()
+    })
 })

--- a/packages/roc-db/src/lib/applyChangeSet.test.ts
+++ b/packages/roc-db/src/lib/applyChangeSet.test.ts
@@ -98,10 +98,6 @@ describe("applyChangeSet", () => {
         const [{ block: row }, rowMutation] = draftAdapter.createBlockRow({
             parentRef: post.ref,
         })
-        engine.mutations.set(rowMutation.ref, {
-            ...engine.mutations.get(rowMutation.ref),
-            persistedAt: rowMutation.timestamp,
-        })
 
         draftAdapter.createBlockParagraph({
             parentRef: row.ref,
@@ -109,9 +105,19 @@ describe("applyChangeSet", () => {
         })
 
         const [, deleteMutation] = draftAdapter.deleteBlocks([row.ref])
+
+        // Simulate sync responses landing after all three local mutations have
+        // been authored: the row's persistedAt is later than the paragraph's
+        // timestamp, mirroring the real `persistOptimisticMutations` path which
+        // stamps persistedAt with wall-clock time at persist receipt.
+        const syncedAt = new Date().toISOString()
+        engine.mutations.set(rowMutation.ref, {
+            ...engine.mutations.get(rowMutation.ref),
+            persistedAt: syncedAt,
+        })
         engine.mutations.set(deleteMutation.ref, {
             ...engine.mutations.get(deleteMutation.ref),
-            persistedAt: deleteMutation.timestamp,
+            persistedAt: syncedAt,
         })
 
         expect(() => adapter.applyDraftTest(draft.ref)).not.toThrow()

--- a/packages/roc-db/src/utils/sortMutations.test.ts
+++ b/packages/roc-db/src/utils/sortMutations.test.ts
@@ -2,29 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { sortMutations } from "./sortMutations"
 
 describe("sortMutations", () => {
-    test("if all documents have persistedAt returns oldest first", async () => {
-        const res = sortMutations([
-            { persistedAt: "2021-01-01T00:00:03Z", ref: "3" },
-            { persistedAt: "2021-01-01T00:00:01Z", ref: "1" },
-            { persistedAt: "2021-01-01T00:00:02Z", ref: "2" },
-        ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
-    })
-
-    test("uses persistedAt when present, timestamp otherwise, as a single sort key", async () => {
-        const res = sortMutations([
-            { timestamp: "2021-01-01T00:00:02Z", ref: "2" },
-            {
-                persistedAt: "2021-01-01T00:00:03Z",
-                timestamp: "2020-12-31T00:00:00Z",
-                ref: "3",
-            },
-            { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
-        ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
-    })
-
-    test("timestamps only", async () => {
+    test("sorts by timestamp ascending", async () => {
         const res = sortMutations([
             { timestamp: "2021-01-01T00:00:03Z", ref: "3" },
             { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
@@ -33,7 +11,7 @@ describe("sortMutations", () => {
         expect(res).toStrictEqual(["1", "2", "3"])
     })
 
-    test("timestamps equal ref is used secondary", async () => {
+    test("ties on timestamp fall back to ref", async () => {
         const res = sortMutations([
             { timestamp: "2021-01-01T00:00:01Z", ref: "3" },
             { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
@@ -42,21 +20,25 @@ describe("sortMutations", () => {
         expect(res).toStrictEqual(["1", "2", "3"])
     })
 
-    test("preserves logical creation order when persistedAt is missing on some mutations", async () => {
+    test("ignores persistedAt, even when it would reorder against timestamp", async () => {
+        // Realistic scenario: mutation 1 is created first, then 2 is created
+        // locally before 1's sync completes, then 1's persistedAt arrives with
+        // a wall-clock time later than 2's timestamp. Sort must still respect
+        // authorship order (timestamp), not persistence order.
         const res = sortMutations([
-            {
-                ref: "1",
-                timestamp: "2021-01-01T00:00:01.000Z",
-                persistedAt: "2021-01-01T00:00:01.500Z",
-            },
             {
                 ref: "2",
                 timestamp: "2021-01-01T00:00:02.000Z",
             },
             {
+                ref: "1",
+                timestamp: "2021-01-01T00:00:01.000Z",
+                persistedAt: "2021-01-01T00:00:05.000Z",
+            },
+            {
                 ref: "3",
                 timestamp: "2021-01-01T00:00:03.000Z",
-                persistedAt: "2021-01-01T00:00:03.500Z",
+                persistedAt: "2021-01-01T00:00:05.000Z",
             },
         ]).map(mutation => mutation.ref)
         expect(res).toStrictEqual(["1", "2", "3"])

--- a/packages/roc-db/src/utils/sortMutations.test.ts
+++ b/packages/roc-db/src/utils/sortMutations.test.ts
@@ -2,29 +2,51 @@ import { describe, expect, test } from "bun:test"
 import { sortMutations } from "./sortMutations"
 
 describe("sortMutations", () => {
-    test("sorts by timestamp ascending", async () => {
+    test("when all mutations are persisted, sorts by persistedAt", async () => {
         const res = sortMutations([
-            { timestamp: "2021-01-01T00:00:03Z", ref: "3" },
-            { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
-            { timestamp: "2021-01-01T00:00:02Z", ref: "2" },
+            {
+                ref: "3",
+                timestamp: "2021-01-01T00:00:01Z",
+                persistedAt: "2021-01-01T00:00:30Z",
+            },
+            {
+                ref: "1",
+                timestamp: "2021-01-01T00:00:03Z",
+                persistedAt: "2021-01-01T00:00:10Z",
+            },
+            {
+                ref: "2",
+                timestamp: "2021-01-01T00:00:02Z",
+                persistedAt: "2021-01-01T00:00:20Z",
+            },
         ]).map(mutation => mutation.ref)
         expect(res).toStrictEqual(["1", "2", "3"])
     })
 
-    test("ties on timestamp fall back to ref", async () => {
+    test("when any mutation is unpersisted, sorts by timestamp", async () => {
         const res = sortMutations([
-            { timestamp: "2021-01-01T00:00:01Z", ref: "3" },
-            { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
-            { timestamp: "2021-01-01T00:00:01Z", ref: "2" },
+            { ref: "3", timestamp: "2021-01-01T00:00:03Z" },
+            { ref: "1", timestamp: "2021-01-01T00:00:01Z" },
+            { ref: "2", timestamp: "2021-01-01T00:00:02Z" },
         ]).map(mutation => mutation.ref)
         expect(res).toStrictEqual(["1", "2", "3"])
     })
 
-    test("ignores persistedAt, even when it would reorder against timestamp", async () => {
-        // Realistic scenario: mutation 1 is created first, then 2 is created
-        // locally before 1's sync completes, then 1's persistedAt arrives with
-        // a wall-clock time later than 2's timestamp. Sort must still respect
-        // authorship order (timestamp), not persistence order.
+    test("ties on the sort key fall back to ref", async () => {
+        const res = sortMutations([
+            { ref: "3", timestamp: "2021-01-01T00:00:01Z" },
+            { ref: "1", timestamp: "2021-01-01T00:00:01Z" },
+            { ref: "2", timestamp: "2021-01-01T00:00:01Z" },
+        ]).map(mutation => mutation.ref)
+        expect(res).toStrictEqual(["1", "2", "3"])
+    })
+
+    test("mixed set ignores persistedAt entirely, sorts the persisted ones by their timestamp", async () => {
+        // The realistic optimistic-apply scenario: mutation 1 was authored
+        // first and its sync round-trip stamped persistedAt with wall-clock
+        // time *after* mutation 2 was authored locally. Sort must still
+        // respect authorship order — `persistedAt` is irrelevant when any
+        // mutation in the set is unpersisted.
         const res = sortMutations([
             {
                 ref: "2",

--- a/packages/roc-db/src/utils/sortMutations.test.ts
+++ b/packages/roc-db/src/utils/sortMutations.test.ts
@@ -11,11 +11,15 @@ describe("sortMutations", () => {
         expect(res).toStrictEqual(["1", "2", "3"])
     })
 
-    test("persistedAt should always come before timestamp", async () => {
+    test("uses persistedAt when present, timestamp otherwise, as a single sort key", async () => {
         const res = sortMutations([
-            { timestamp: "2021-01-01T00:00:02Z", ref: "3" },
-            { persistedAt: "2021-01-01T00:00:03Z", ref: "1" },
-            { timestamp: "2021-01-01T00:00:01Z", ref: "2" },
+            { timestamp: "2021-01-01T00:00:02Z", ref: "2" },
+            {
+                persistedAt: "2021-01-01T00:00:03Z",
+                timestamp: "2020-12-31T00:00:00Z",
+                ref: "3",
+            },
+            { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
         ]).map(mutation => mutation.ref)
         expect(res).toStrictEqual(["1", "2", "3"])
     })
@@ -34,6 +38,26 @@ describe("sortMutations", () => {
             { timestamp: "2021-01-01T00:00:01Z", ref: "3" },
             { timestamp: "2021-01-01T00:00:01Z", ref: "1" },
             { timestamp: "2021-01-01T00:00:01Z", ref: "2" },
+        ]).map(mutation => mutation.ref)
+        expect(res).toStrictEqual(["1", "2", "3"])
+    })
+
+    test("preserves logical creation order when persistedAt is missing on some mutations", async () => {
+        const res = sortMutations([
+            {
+                ref: "1",
+                timestamp: "2021-01-01T00:00:01.000Z",
+                persistedAt: "2021-01-01T00:00:01.500Z",
+            },
+            {
+                ref: "2",
+                timestamp: "2021-01-01T00:00:02.000Z",
+            },
+            {
+                ref: "3",
+                timestamp: "2021-01-01T00:00:03.000Z",
+                persistedAt: "2021-01-01T00:00:03.500Z",
+            },
         ]).map(mutation => mutation.ref)
         expect(res).toStrictEqual(["1", "2", "3"])
     })

--- a/packages/roc-db/src/utils/sortMutations.test.ts
+++ b/packages/roc-db/src/utils/sortMutations.test.ts
@@ -5,43 +5,69 @@ describe("sortMutations", () => {
     test("when all mutations are persisted, sorts by persistedAt", async () => {
         const res = sortMutations([
             {
-                ref: "3",
+                ref: "Mutation/1063354369557194121217",
                 timestamp: "2021-01-01T00:00:01Z",
                 persistedAt: "2021-01-01T00:00:30Z",
             },
             {
-                ref: "1",
+                ref: "Mutation/1063354369557194121218",
                 timestamp: "2021-01-01T00:00:03Z",
                 persistedAt: "2021-01-01T00:00:10Z",
             },
             {
-                ref: "2",
+                ref: "Mutation/1063354369557194121219",
                 timestamp: "2021-01-01T00:00:02Z",
                 persistedAt: "2021-01-01T00:00:20Z",
             },
-        ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
+        ]).map(mutation => mutation.persistedAt)
+        expect(res).toStrictEqual([
+            "2021-01-01T00:00:10Z",
+            "2021-01-01T00:00:20Z",
+            "2021-01-01T00:00:30Z",
+        ])
     })
 
     test("when any mutation is unpersisted, sorts by timestamp", async () => {
         const res = sortMutations([
-            { ref: "3", timestamp: "2021-01-01T00:00:03Z" },
-            { ref: "1", timestamp: "2021-01-01T00:00:01Z" },
-            { ref: "2", timestamp: "2021-01-01T00:00:02Z" },
-        ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
+            {
+                ref: "Mutation/1063354369557194121217",
+                timestamp: "2021-01-01T00:00:03Z",
+            },
+            {
+                ref: "Mutation/1063354369557194121218",
+                timestamp: "2021-01-01T00:00:01Z",
+            },
+            {
+                ref: "Mutation/1063354369557194121219",
+                timestamp: "2021-01-01T00:00:02Z",
+            },
+        ]).map(mutation => mutation.timestamp)
+        expect(res).toStrictEqual([
+            "2021-01-01T00:00:01Z",
+            "2021-01-01T00:00:02Z",
+            "2021-01-01T00:00:03Z",
+        ])
     })
 
-    test("ties on the sort key fall back to ref", async () => {
+    test("ties on the sort key fall back to numeric id (creation order), not lexical", async () => {
+        // All three share one persistedAt (e.g. a batch persisted in a single
+        // persistOptimisticMutations call). The tiebreak must order by the
+        // numeric snowflake id. These ids differ in decimal length, so a
+        // lexical compare would put "10…" before "9…" — wrong.
+        const persistedAt = "2021-01-01T00:00:00Z"
         const res = sortMutations([
-            { ref: "3", timestamp: "2021-01-01T00:00:01Z" },
-            { ref: "1", timestamp: "2021-01-01T00:00:01Z" },
-            { ref: "2", timestamp: "2021-01-01T00:00:01Z" },
+            { ref: "Mutation/10000000000000000000", persistedAt },
+            { ref: "Mutation/9000000000000000000", persistedAt },
+            { ref: "Mutation/9500000000000000000", persistedAt },
         ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
+        expect(res).toStrictEqual([
+            "Mutation/9000000000000000000",
+            "Mutation/9500000000000000000",
+            "Mutation/10000000000000000000",
+        ])
     })
 
-    test("mixed set ignores persistedAt entirely, sorts the persisted ones by their timestamp", async () => {
+    test("mixed set ignores persistedAt entirely, sorts by timestamp", async () => {
         // The realistic optimistic-apply scenario: mutation 1 was authored
         // first and its sync round-trip stamped persistedAt with wall-clock
         // time *after* mutation 2 was authored locally. Sort must still
@@ -49,20 +75,24 @@ describe("sortMutations", () => {
         // mutation in the set is unpersisted.
         const res = sortMutations([
             {
-                ref: "2",
+                ref: "Mutation/1063354369557194121218",
                 timestamp: "2021-01-01T00:00:02.000Z",
             },
             {
-                ref: "1",
+                ref: "Mutation/1063354369557194121217",
                 timestamp: "2021-01-01T00:00:01.000Z",
                 persistedAt: "2021-01-01T00:00:05.000Z",
             },
             {
-                ref: "3",
+                ref: "Mutation/1063354369557194121219",
                 timestamp: "2021-01-01T00:00:03.000Z",
                 persistedAt: "2021-01-01T00:00:05.000Z",
             },
-        ]).map(mutation => mutation.ref)
-        expect(res).toStrictEqual(["1", "2", "3"])
+        ]).map(mutation => mutation.timestamp)
+        expect(res).toStrictEqual([
+            "2021-01-01T00:00:01.000Z",
+            "2021-01-01T00:00:02.000Z",
+            "2021-01-01T00:00:03.000Z",
+        ])
     })
 })

--- a/packages/roc-db/src/utils/sortMutations.ts
+++ b/packages/roc-db/src/utils/sortMutations.ts
@@ -1,16 +1,14 @@
 export const sortMutations = documents => {
     return [...documents].sort((a, b) => {
-        if (a.persistedAt && b.persistedAt) {
-            return a.persistedAt.localeCompare(b.persistedAt)
-        } else if (a.persistedAt) {
-            return -1 // a is persisted, b is not
-        } else if (b.persistedAt) {
-            return 1 // b is persisted, a is not
-        } else if (a.timestamp !== b.timestamp) {
-            return a.timestamp.localeCompare(b.timestamp) // Older timestamps first
-        } else {
-            // If timestamps are equal, sort by ref alphabetically
-            return a.ref.localeCompare(b.ref)
+        // Use persistedAt when present, fall back to timestamp. This preserves
+        // causal order when a changeSet mixes persisted and not-yet-persisted
+        // mutations — e.g. a user-made step that landed between a persisted
+        // create and a persisted delete must still replay in the middle.
+        const aKey = a.persistedAt ?? a.timestamp
+        const bKey = b.persistedAt ?? b.timestamp
+        if (aKey !== bKey) {
+            return aKey.localeCompare(bKey)
         }
+        return a.ref.localeCompare(b.ref)
     })
 }

--- a/packages/roc-db/src/utils/sortMutations.ts
+++ b/packages/roc-db/src/utils/sortMutations.ts
@@ -1,12 +1,17 @@
 export const sortMutations = documents => {
+    // Pick a single sort key per call:
+    //   - If every mutation has `persistedAt` (typical on the server, or a
+    //     fully-synced multi-client changeSet): sort by `persistedAt`, the
+    //     only clock that's coherent across clients.
+    //   - Otherwise (optimistic local apply with in-flight or offline
+    //     mutations): sort by `timestamp`, the authoring client's causal
+    //     clock. Mixing the two reorders dependent mutations on replay
+    //     because `persistedAt` is wall-clock at persist receipt and can
+    //     land after a later mutation's `timestamp`.
+    const key = documents.every(d => d.persistedAt) ? "persistedAt" : "timestamp"
     return [...documents].sort((a, b) => {
-        // Sort strictly by `timestamp` (the authoring client's causal clock).
-        // `persistedAt` is server-side bookkeeping assigned at persist receipt,
-        // which can land after a later mutation's `timestamp` when syncs are
-        // delayed — mixing the two clocks reorders dependent mutations on
-        // replay.
-        if (a.timestamp !== b.timestamp) {
-            return a.timestamp.localeCompare(b.timestamp)
+        if (a[key] !== b[key]) {
+            return a[key].localeCompare(b[key])
         }
         return a.ref.localeCompare(b.ref)
     })

--- a/packages/roc-db/src/utils/sortMutations.ts
+++ b/packages/roc-db/src/utils/sortMutations.ts
@@ -1,13 +1,12 @@
 export const sortMutations = documents => {
     return [...documents].sort((a, b) => {
-        // Use persistedAt when present, fall back to timestamp. This preserves
-        // causal order when a changeSet mixes persisted and not-yet-persisted
-        // mutations — e.g. a user-made step that landed between a persisted
-        // create and a persisted delete must still replay in the middle.
-        const aKey = a.persistedAt ?? a.timestamp
-        const bKey = b.persistedAt ?? b.timestamp
-        if (aKey !== bKey) {
-            return aKey.localeCompare(bKey)
+        // Sort strictly by `timestamp` (the authoring client's causal clock).
+        // `persistedAt` is server-side bookkeeping assigned at persist receipt,
+        // which can land after a later mutation's `timestamp` when syncs are
+        // delayed — mixing the two clocks reorders dependent mutations on
+        // replay.
+        if (a.timestamp !== b.timestamp) {
+            return a.timestamp.localeCompare(b.timestamp)
         }
         return a.ref.localeCompare(b.ref)
     })

--- a/packages/roc-db/src/utils/sortMutations.ts
+++ b/packages/roc-db/src/utils/sortMutations.ts
@@ -1,3 +1,5 @@
+import { idFromRef } from "./idFromRef"
+
 export const sortMutations = documents => {
     // Pick a single sort key per call:
     //   - If every mutation has `persistedAt` (typical on the server, or a
@@ -13,6 +15,14 @@ export const sortMutations = documents => {
         if (a[key] !== b[key]) {
             return a[key].localeCompare(b[key])
         }
-        return a.ref.localeCompare(b.ref)
+        // Deterministic tiebreak on the snowflake id so equal keys (e.g. a
+        // whole batch sharing one `persistedAt`, or two writes in the same
+        // millisecond) still replay in creation order. The id's high bits are
+        // the timestamp, so numeric id order == single-client creation order.
+        // Compare as BigInt: ids exceed Number.MAX_SAFE_INTEGER and vary in
+        // decimal length, so a lexical compare would misorder them.
+        const aId = BigInt(idFromRef(a.ref))
+        const bId = BigInt(idFromRef(b.ref))
+        return aId < bId ? -1 : aId > bId ? 1 : 0
     })
 }

--- a/packages/roc-db/src/utils/sortMutations.ts
+++ b/packages/roc-db/src/utils/sortMutations.ts
@@ -11,18 +11,22 @@ export const sortMutations = documents => {
     //     because `persistedAt` is wall-clock at persist receipt and can
     //     land after a later mutation's `timestamp`.
     const key = documents.every(d => d.persistedAt) ? "persistedAt" : "timestamp"
-    return [...documents].sort((a, b) => {
-        if (a[key] !== b[key]) {
-            return a[key].localeCompare(b[key])
-        }
-        // Deterministic tiebreak on the snowflake id so equal keys (e.g. a
-        // whole batch sharing one `persistedAt`, or two writes in the same
-        // millisecond) still replay in creation order. The id's high bits are
-        // the timestamp, so numeric id order == single-client creation order.
-        // Compare as BigInt: ids exceed Number.MAX_SAFE_INTEGER and vary in
-        // decimal length, so a lexical compare would misorder them.
-        const aId = BigInt(idFromRef(a.ref))
-        const bId = BigInt(idFromRef(b.ref))
-        return aId < bId ? -1 : aId > bId ? 1 : 0
-    })
+    // Decorate once so each id is parsed to a BigInt a single time rather than
+    // on every comparison. A tied key — e.g. a whole batch sharing one
+    // `persistedAt` — makes every comparison reach the id tiebreak, so without
+    // this the parsing cost is O(n log n) instead of O(n).
+    return documents
+        .map(doc => ({ doc, sortKey: doc[key], id: BigInt(idFromRef(doc.ref)) }))
+        .sort((a, b) => {
+            if (a.sortKey !== b.sortKey) {
+                return a.sortKey.localeCompare(b.sortKey)
+            }
+            // Deterministic tiebreak on the snowflake id so equal keys still
+            // replay in creation order. The id's high bits are the timestamp,
+            // so numeric id order == single-client creation order. Compare as
+            // BigInt: ids exceed Number.MAX_SAFE_INTEGER and vary in decimal
+            // length, so a lexical compare would misorder them.
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+        })
+        .map(entry => entry.doc)
 }


### PR DESCRIPTION
## Summary

Fixes `sortMutations` so `applyChangeSet` / `loadMutations` replay a changeSet's mutations in a deterministic, dependency-safe order. Two distinct ordering bugs:

1. **Mixed persisted/unpersisted reordering.** A changeSet mixing persisted and not-yet-persisted mutations could replay out of causal order — e.g. a delete running before a dependent create and failing with `Entity not found`. Reported in Slack: AI created a parent decision (persisted), user added a step locally (not yet persisted), AI deleted the decision (persisted) — replay ran delete before the step's create.
2. **Nondeterministic ties.** When the sort key tied (a whole batch sharing one `persistedAt` — `persistOptimisticMutations` stamps the batch with a single wall-clock value — or two writes in the same millisecond), the tiebreak was a lexical string compare, which misorders snowflake ids.

### Fix

**Key selection (per call, not per mutation):**

- **All mutations have `persistedAt`** → sort by `persistedAt`. The canonical server clock, the only ordering coherent across clients. Server applies always take this path (server only processes persisted mutations); fully-synced multi-client changeSets do too.
- **Any mutation missing `persistedAt`** → sort by `timestamp`. The authoring client's causal clock, set once at creation. Optimistic local apply takes this path.

Why not a per-mutation fallback (`persistedAt ?? timestamp`): `persistOptimisticMutations` stamps `persistedAt` with wall-clock time at persist receipt, which can land *after* a later mutation's `timestamp` when syncs are delayed — mixing the two clocks in one comparator reorders dependent mutations.

**Deterministic total order:** when the chosen key ties, tiebreak on the snowflake id parsed as `BigInt`. The id's high bits are the timestamp, so numeric id order == single-client creation order, and a tied batch replays in creation order. Compared as `BigInt` because ids exceed `Number.MAX_SAFE_INTEGER` and vary in decimal length, so a lexical compare misorders them at power-of-10 boundaries (`Mutation/10…` before `Mutation/9…`).

**Performance:** ids are parsed once via decorate-sort-undecorate rather than inside the comparator — a tied key makes every comparison reach the tiebreak, so this is O(n) parses instead of O(n log n).

### Known trade-off

Optimistic apply on a multi-client changeSet with one in-flight local mutation could place the local mutation in the wrong spot relative to a remote mutation (different clocks). The server's eventual apply, where everything is persisted, is canonical and replays correctly.

## Tests

`sortMutations.test.ts`:
- All-persisted → orders by `persistedAt`.
- Any-unpersisted → orders by `timestamp`.
- Mixed set ignores `persistedAt` even when it would reorder against `timestamp` (the optimistic case where a persisted mutation's `persistedAt` lands after a later mutation's `timestamp`).
- Tied key falls back to **numeric** id, not lexical — uses differing-length ids that a lexical compare would misorder.

`applyChangeSet.test.ts`:
- Integration test reproducing the `Entity not found: BlockRow/...` crash: authors a row, a paragraph child of the row, then a delete of the row, then stamps `persistedAt` on the row and delete *after* all three exist (mirroring real `persistOptimisticMutations` timing).

## Test plan
- [x] `bun test packages/roc-db/src/utils/sortMutations.test.ts` — 4/4 pass
- [x] `bun test packages/roc-db/src/lib/applyChangeSet.test.ts` — 2/2 pass
- [x] Verified the integration test fails with `Entity not found: BlockRow/...` when the sort fix is reverted, passes when restored.
- [x] Verified the numeric tiebreak test fails on a lexical compare (longer `10…` id sorts before `9…`) and passes on `BigInt`.
- [x] Full suite: same 17 pre-existing failures as `main`, no new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)