### PR TITLE
Make IndexedDB adapter pass the shared conformance suite

### DIFF
--- a/.changeset/indexed-db-conformance.md
+++ b/.changeset/indexed-db-conformance.md
@@ -1,0 +1,5 @@
+---
+"@roc-db/indexed-db": patch
+---
+
+The IndexedDB adapter now passes the shared adapter conformance suite (`testAdapterImplementation`), matching `@roc-db/in-memory` and `@roc-db/postgres`. Fixes the `begin()` transaction lifecycle (resolve only after the transaction commits, reuse the connection), honours the injected `snowflake` instead of always creating a new one, scopes debounce lookups by `identityRef`, and surfaces unique-constraint violations as `ConflictError`.

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.test.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.test.ts
@@ -1,5 +1,6 @@
-import { describe } from "bun:test"
-import { testAdapterImplementation } from "@roc-db/test-utils"
+import { describe, expect, test } from "bun:test"
+import { entities, operations, testAdapterImplementation } from "@roc-db/test-utils"
+import { Snowflake } from "roc-db"
 import { createIndexedDBAdapter } from "./createIndexedDBAdapter"
 import type { IndexedDBEngine } from "./types/IndexedDBEngine"
 
@@ -7,4 +8,82 @@ describe("createIndexedDBAdapter", () => {
     testAdapterImplementation<IndexedDBEngine>(createIndexedDBAdapter, () => ({
         dbName: crypto.randomUUID().slice(0, 8),
     }))
+})
+
+// White-box regression test that can't be expressed through the shared
+// black-box conformance suite: it seeds a corrupt store state directly.
+describe("findDebounceMutation with multiple matches", () => {
+    // Open the same named database the adapter uses and commit rows straight
+    // into the "mutations" store, bypassing the adapter's write path.
+    const seedMutations = (dbName: string, rows: any[]) =>
+        new Promise<void>((resolve, reject) => {
+            const openReq = indexedDB.open(dbName)
+            openReq.onsuccess = () => {
+                const db = openReq.result
+                const txn = db.transaction(["mutations"], "readwrite")
+                const store = txn.objectStore("mutations")
+                rows.forEach(row => store.put(row))
+                txn.oncomplete = () => {
+                    db.close()
+                    resolve()
+                }
+                txn.onerror = () => reject(txn.error)
+            }
+            openReq.onerror = () => reject(openReq.error)
+        })
+
+    const withTimeout = <T>(promise: Promise<T>, ms: number, label: string) =>
+        Promise.race([
+            promise,
+            new Promise<never>((_, reject) =>
+                setTimeout(
+                    () => reject(new Error(`Timed out waiting for ${label}`)),
+                    ms,
+                ),
+            ),
+        ])
+
+    test("rejects instead of hanging when two debounced mutations collide", async () => {
+        const dbName = crypto.randomUUID().slice(0, 8)
+        const adapter = createIndexedDBAdapter({
+            operations,
+            entities,
+            session: { identityRef: "User/42" },
+            snowflake: new Snowflake(10, 10),
+            dbName,
+        })
+
+        const [post] = await adapter.createPost({ title: "Title 1" })
+
+        // Two mutations that both satisfy the debounce match criteria for an
+        // updatePostTitle on this post from this identity, inside the debounce
+        // window. This is a state the write path should never produce, but the
+        // guard for it must surface as a rejection rather than an unsettled
+        // promise (a thrown error inside an IDBRequest.onsuccess handler does
+        // not reject the surrounding Promise).
+        const now = new Date().toISOString()
+        const baseMutation = {
+            timestamp: now,
+            operation: { name: "updatePostTitle", version: 1 },
+            payload: { ref: post.ref, title: "Collide" },
+            log: [],
+            changeSetRef: null,
+            debounceCount: 0,
+            sessionRef: null,
+            identityRef: "User/42",
+            persistedAt: now,
+        }
+        await seedMutations(dbName, [
+            { ...baseMutation, ref: "Mutation/collision-1" },
+            { ...baseMutation, ref: "Mutation/collision-2" },
+        ])
+
+        await expect(
+            withTimeout(
+                adapter.updatePostTitle({ ref: post.ref, title: "New title" }),
+                1000,
+                "updatePostTitle",
+            ),
+        ).rejects.toThrow("Unhandled multiple debounced mutations")
+    })
 })

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.test.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.test.ts
@@ -4,7 +4,7 @@ import { createIndexedDBAdapter } from "./createIndexedDBAdapter"
 import type { IndexedDBEngine } from "./types/IndexedDBEngine"
 
 describe("createIndexedDBAdapter", () => {
-    // testAdapterImplementation<IndexedDBEngine>(createIndexedDBAdapter, () => ({
-    //     dbName: crypto.randomUUID().slice(0, 8),
-    // }))
+    testAdapterImplementation<IndexedDBEngine>(createIndexedDBAdapter, () => ({
+        dbName: crypto.randomUUID().slice(0, 8),
+    }))
 })

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
@@ -7,6 +7,7 @@ export const createIndexedDBAdapter = ({
     session,
     dbName = "roc-db",
     optimistic = false,
+    snowflake = new Snowflake(1, 1),
 }) => {
     return createAdapter(
         {
@@ -16,7 +17,7 @@ export const createIndexedDBAdapter = ({
             functions,
             optimistic,
             session,
-            snowflake: new Snowflake(1, 1),
+            snowflake,
             async: true,
         },
         {

--- a/packages/@roc-db/indexed-db/src/functions/begin.ts
+++ b/packages/@roc-db/indexed-db/src/functions/begin.ts
@@ -1,8 +1,11 @@
-export const begin = async (engineOpts, callback) => {
-    return new Promise((resolve, reject) => {
-        let db
-        const idbRequest = indexedDB.open(engineOpts.dbName, 1)
-        idbRequest.onupgradeneeded = event => {
+const DB_CACHE = new WeakMap()
+
+const openDatabase = engineOpts => {
+    let cached = DB_CACHE.get(engineOpts)
+    if (cached) return cached
+    const promise = new Promise((resolve, reject) => {
+        const idbRequest = indexedDB.open(engineOpts.dbName, engineOpts.version)
+        idbRequest.onupgradeneeded = () => {
             const entitiesObjectStore = idbRequest.result.createObjectStore(
                 "entities",
                 { keyPath: "ref" },
@@ -33,20 +36,70 @@ export const begin = async (engineOpts, callback) => {
             })
         }
 
-        idbRequest.onsuccess = event => {
-            db = idbRequest.result
-
-            resolve(
-                callback({
-                    ...engineOpts,
-                    db,
-                    txn: db.transaction(
-                        ["entities", "mutations"],
-                        "readwrite",
-                        // request.type === "write" ? "readwrite" : "readonly",
-                    ),
-                }),
-            )
+        idbRequest.onsuccess = () => {
+            resolve(idbRequest.result)
         }
+        idbRequest.onerror = () => {
+            DB_CACHE.delete(engineOpts)
+            reject(idbRequest.error)
+        }
+    })
+    DB_CACHE.set(engineOpts, promise)
+    return promise
+}
+
+export const begin = async (engineOpts, callback) => {
+    const db = await openDatabase(engineOpts)
+    return new Promise((resolve, reject) => {
+        const txn = db.transaction(["entities", "mutations"], "readwrite")
+
+        let callbackResult
+        let callbackDone = false
+        let txnComplete = false
+        let settled = false
+
+        const maybeResolve = () => {
+            if (settled) return
+            if (callbackDone && txnComplete) {
+                settled = true
+                resolve(callbackResult)
+            }
+        }
+
+        txn.oncomplete = () => {
+            txnComplete = true
+            maybeResolve()
+        }
+        txn.onerror = event => {
+            if (settled) return
+            settled = true
+            reject(event.target.error)
+        }
+        txn.onabort = () => {
+            if (settled) return
+            settled = true
+            reject(txn.error ?? new Error("Transaction aborted"))
+        }
+
+        Promise.resolve(
+            callback({
+                ...engineOpts,
+                db,
+                txn,
+            }),
+        )
+            .then(result => {
+                callbackResult = result
+                callbackDone = true
+                maybeResolve()
+            })
+            .catch(error => {
+                if (settled) return
+                settled = true
+                try {
+                    txn.abort()
+                } catch {}
+                reject(error)
+            })
     })
 }

--- a/packages/@roc-db/indexed-db/src/functions/begin.ts
+++ b/packages/@roc-db/indexed-db/src/functions/begin.ts
@@ -37,7 +37,16 @@ const openDatabase = engineOpts => {
         }
 
         idbRequest.onsuccess = () => {
-            resolve(idbRequest.result)
+            const db = idbRequest.result
+            // The connection is cached and long-lived. If another connection
+            // requests a version upgrade, close ours and drop it from the
+            // cache so the upgrade isn't blocked and we don't reuse a stale
+            // handle.
+            db.onversionchange = () => {
+                db.close()
+                DB_CACHE.delete(engineOpts)
+            }
+            resolve(db)
         }
         idbRequest.onerror = () => {
             DB_CACHE.delete(engineOpts)
@@ -73,7 +82,7 @@ export const begin = async (engineOpts, callback) => {
         txn.onerror = event => {
             if (settled) return
             settled = true
-            reject(event.target.error)
+            reject(txn.error ?? event.target?.error)
         }
         txn.onabort = () => {
             if (settled) return

--- a/packages/@roc-db/indexed-db/src/functions/commitCreate.ts
+++ b/packages/@roc-db/indexed-db/src/functions/commitCreate.ts
@@ -16,6 +16,11 @@ export const commitCreate: CreateEntityFunction<IndexedDBEngine> = (
         }
         request.onerror = event => {
             if (event?.target?.error?.name === "ConstraintError") {
+                // Prevent the raw ConstraintError from bubbling to (and
+                // aborting via) the transaction's error handler before our
+                // converted ConflictError can propagate through the chain.
+                event.stopPropagation()
+                event.preventDefault()
                 reject(createUniqueConstraintConflictError(document.entity))
             } else {
                 console.error(

--- a/packages/@roc-db/indexed-db/src/functions/findDebounceMutation.ts
+++ b/packages/@roc-db/indexed-db/src/functions/findDebounceMutation.ts
@@ -6,6 +6,7 @@ export const findDebounceMutation = async (
     engine: IndexedDBEngine,
     now: number,
     mutationName: string,
+    identityRef: string,
 ) => {
     const objectStore = engine.txn.objectStore("mutations")
     const index = objectStore.index("timestamp")
@@ -24,7 +25,8 @@ export const findDebounceMutation = async (
                 if (
                     doc.operation.name === mutationName &&
                     doc.payload.ref === request.payload.ref &&
-                    doc.changeSetRef === request.changeSetRef
+                    doc.changeSetRef === request.changeSetRef &&
+                    doc.identityRef === identityRef
                 ) {
                     results.push(doc)
                 }

--- a/packages/@roc-db/indexed-db/src/functions/findDebounceMutation.ts
+++ b/packages/@roc-db/indexed-db/src/functions/findDebounceMutation.ts
@@ -32,17 +32,15 @@ export const findDebounceMutation = async (
                 }
                 cursor.continue()
             } else {
-                if (results.length) {
-                    if (results.length > 1) {
-                        throw new Error(
-                            "Unhandled multiple debounced mutations",
-                        )
-                    }
-                    resolve(results[0])
-                } else {
-                    resolve(undefined)
+                if (results.length > 1) {
+                    reject(new Error("Unhandled multiple debounced mutations"))
+                    return
                 }
+                resolve(results[0])
             }
+        }
+        idbRequest.onerror = () => {
+            reject(idbRequest.error)
         }
     })
 }


### PR DESCRIPTION
## Summary

Enables the shared adapter conformance suite for `@roc-db/indexed-db` (previously commented out since the initial commit) and fixes the adapter so all conformance tests pass. The suite went from **14 fail / 29 pass** to **43 pass / 1 todo / 0 fail**, matching the contract already satisfied by `@roc-db/in-memory` and `@roc-db/postgres`.

The shared test in `@roc-db/test-utils` was **not** modified — the contract is the source of truth.

## Root causes fixed

- **`begin()` transaction lifecycle** (`functions/begin.ts`) — resolved before the IndexedDB transaction committed and opened a fresh connection per operation without ever reusing or closing it. This corrupted state once many operations ran in a single test run (basic CRUD returned `undefined`). Rewrote to cache the DB connection per engine and resolve only after **both** the callback settles **and** the transaction completes; aborts and rejects cleanly on callback error.

- **Ignored injected snowflake** (`createIndexedDBAdapter.ts`) — always constructed a fresh `Snowflake(1, 1)` instead of using the one passed in, so sibling adapters produced identical mutation refs and collided (e.g. `persistOptimisticMutations` skipped mutations as "already exists"). Now accepts and uses the passed `snowflake`, matching the in-memory adapter.

- **Debounce not scoped by identity** (`functions/findDebounceMutation.ts`) — debounce collapsed mutations across different identities, losing audit attribution. Now filters candidates by `identityRef`.

- **Constraint-error propagation** (`functions/commitCreate.ts`) — the raw `ConstraintError` bubbled to the transaction handler and beat the converted `ConflictError`. Added `stopPropagation()` + `preventDefault()` so the `ConflictError` propagates deterministically (and the transaction is rolled back via the explicit abort in `begin`).

## Verification

- `bun --filter '@roc-db/indexed-db' test` → 43 pass, 1 todo, 0 fail (stable across repeated runs)
- `bun run build` (js + types) succeeds for all packages
- `@roc-db/in-memory` tests still pass; `@roc-db/postgres` failures are only local `ECONNREFUSED` (no DB service), unrelated to this change

Note: this repo currently has no Changesets config, CI workflows, or `verify-publish` script, so those steps from the task description were not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)