### PR TITLE
Fix one-transaction duplicateChangeSetMutations; make it server-authoritative

### DIFF
--- a/.changeset/duplicate-server-authoritative.md
+++ b/.changeset/duplicate-server-authoritative.md
@@ -1,0 +1,12 @@
+---
+"roc-db": minor
+"@roc-db/test-utils": patch
+---
+
+Fix the one-transaction `duplicateChangeSetMutations` pattern, and make the primitive server-authoritative.
+
+- **Bug fix — one-transaction duplicate throwing `NotFoundError` for the target root.** When a cloned operation read its own changeSet root (a common validate/attach-against-the-root pattern), replay resolved that read against the persisted store — which does not yet contain the target changeSet root created moments earlier by the same *uncommitted* outer operation — and threw `NotFoundError` for the target ref. The primitive now surfaces the outer transaction's own pending writes (from `txn.log`) onto the replay scratch cache, so same-transaction creations — most importantly the freshly-created target root — are visible to replay. The source base still takes precedence, so copies resolve their base against the source snapshot. Reproduced on the valdres and postgres adapters; now covered by a shared conformance test that runs across all adapters (in-memory, valdres, postgres, indexed-db). This makes the documented one-transaction pattern (create the target root, even with a `parents.version`, then duplicate, all in one write op) actually work.
+
+- **New error `OptimisticDuplicationError`** (extends `BadRequestError`). `duplicateChangeSetMutations` now throws it when invoked on an **optimistic adapter**. The primitive emits the source's mutations as N independent mutation records in the target changeSet; running the wrapping write operation optimistically would sync that operation's own mutation and re-run the primitive on replay (on the server, or on another client via `loadMutations`), double-executing it — producing duplicate copies, or a `ChangeSetNotEmptyError` when the target is already populated. Run the wrapping operation once on a non-optimistic (server) adapter and load the resulting mutations on clients; do not replay the wrapping operation on clients — load the granular copies it produced instead.
+
+  **Action required:** the in-memory and valdres adapters default to `optimistic: true`. If you duplicate a changeSet from one of those, construct the adapter used for duplication with `optimistic: false`.

--- a/packages/@roc-db/test-utils/src/operations/createBlockRowReadingRoot.ts
+++ b/packages/@roc-db/test-utils/src/operations/createBlockRowReadingRoot.ts
@@ -1,0 +1,47 @@
+import { Query, QueryChain, writeOperation } from "roc-db"
+import { z } from "zod"
+import { BlockRowRefSchema } from "../schemas/BlockRowRefSchema"
+import { PostRefSchema } from "../schemas/PostRefSchema"
+
+/**
+ * Like `createBlockRow`, but it reads its own changeSet root before creating the
+ * block — a common "validate/attach against the changeSet root" pattern. When a
+ * mutation of this op is cloned into a freshly-created target and replayed, that
+ * read resolves the TARGET root. In the one-transaction duplicate pattern the
+ * target root is created (uncommitted) by the same outer operation, so the
+ * primitive must surface the outer transaction's pending writes to replay —
+ * otherwise this read throws NotFoundError for the target changeSet ref.
+ */
+export const createBlockRowReadingRoot = writeOperation(
+    "createBlockRowReadingRoot",
+    z
+        .object({ parentRef: z.union([PostRefSchema, BlockRowRefSchema]) })
+        .strict(),
+    txn => {
+        const ref = txn.createRef("BlockRow")
+        const { parentRef } = txn.payload
+        return QueryChain(
+            // Read the changeSet root (the target root, during replay).
+            Query(() => {
+                if (txn.changeSetRef) txn.readEntity(txn.changeSetRef)
+            }),
+            Query(() => txn.readEntity(parentRef)),
+            Query(parent =>
+                txn.patchEntity(parentRef, {
+                    children: { blocks: [...parent.children.blocks, ref] },
+                }),
+            ),
+            Query(() =>
+                txn.createEntity(ref, {
+                    children: { blocks: [] },
+                    parents: { parent: parentRef },
+                }),
+            ),
+            Query(block => ({ block })),
+        )
+    },
+    {
+        changeSetOnly: true,
+        outputSchema: z.object({ block: z.any() }),
+    },
+)

--- a/packages/@roc-db/test-utils/src/operations/index.ts
+++ b/packages/@roc-db/test-utils/src/operations/index.ts
@@ -2,6 +2,7 @@ import { applyDraft } from "./applyDraft"
 import { createBlockImage } from "./createBlockImage"
 import { createBlockParagrah } from "./createBlockParagraph"
 import { createBlockRow } from "./createBlockRow"
+import { createBlockRowReadingRoot } from "./createBlockRowReadingRoot"
 import { createBlockTitle } from "./createBlockTitle"
 import { createDraft } from "./createDraft"
 import { createOrgSettings } from "./createOrgSettings"
@@ -40,6 +41,7 @@ export const operations: any[] = [
     createBlockTitle,
     createBlockParagrah,
     createBlockRow,
+    createBlockRowReadingRoot,
     createDraft,
     createOrgSettings,
     createPost,

--- a/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
+++ b/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
@@ -634,6 +634,36 @@ export const testAdapterImplementation = async <EngineOptions extends {}>(
             )
         })
 
+        test("duplicateDraft when a source op reads the changeSet root (one-transaction, pending target root)", async () => {
+            const [post] = await adapter1.createPost({
+                title: "Title 1",
+                slug: faker.lorem.slug(5),
+            })
+            const [sourceDraft] = await adapter1.createDraft({
+                postRef: post.ref,
+            })
+            // A source mutation whose op reads its own changeSet root. When
+            // cloned, replay reads the freshly-created (uncommitted) target root
+            // in the SAME transaction — which must resolve, not throw
+            // NotFoundError(target).
+            await adapter1
+                .changeSet(sourceDraft.ref)
+                .createBlockRowReadingRoot({ parentRef: post.ref })
+
+            const [{ draftRef: newDraftRef, mutations, refMap }] =
+                await adapter1.duplicateDraft({
+                    sourceRef: sourceDraft.ref,
+                    postRef: post.ref,
+                })
+
+            expect(mutations).toHaveLength(1)
+            expect(mutations[0].operation.name).toBe("createBlockRowReadingRoot")
+            const newRow = [...refMap.values()][0]
+            expect(newRow).toBeDefined()
+            const targetCs = adapter1.changeSet(newDraftRef)
+            expect((await targetCs.readEntity(newRow)).ref).toBe(newRow)
+        })
+
         test("deleteBlocks (patch running 2 times removing on array element every time)", async () => {
             const [post, createPostMutation] = await adapter1.createPost({
                 title: "Title 1",

--- a/packages/@roc-db/valdres/src/createValdresAdapter.test.ts
+++ b/packages/@roc-db/valdres/src/createValdresAdapter.test.ts
@@ -144,7 +144,7 @@ test("mutation stored in root store", () => {
     expect(rootStore.get(mutationFamily)).toHaveLength(3)
 })
 
-const prepareChangeSetTest = () => {
+const prepareChangeSetTest = ({ optimistic }: { optimistic?: boolean } = {}) => {
     const rootStore = store()
     const entityFamily = atomFamily(null)
     const mutationFamily = atomFamily(null)
@@ -157,6 +157,7 @@ const prepareChangeSetTest = () => {
         operations,
         session: { identityRef: "User/42" },
         entities,
+        ...(optimistic === undefined ? {} : { optimistic }),
     })
     expect(rootStore.get(mutationFamily)).toHaveLength(0)
     const [post] = adapter.createPost({ title: "Foo" })
@@ -174,7 +175,11 @@ const prepareChangeSetTest = () => {
 }
 
 test("duplicateDraft (txn.duplicateChangeSetMutations) clones a changeSet with remapped refs", () => {
-    const { adapter, post, draft, changeSetAdapter } = prepareChangeSetTest()
+    // Duplication is server-authoritative: run it on a non-optimistic adapter
+    // (valdres defaults to optimistic: true).
+    const { adapter, post, draft, changeSetAdapter } = prepareChangeSetTest({
+        optimistic: false,
+    })
     const [{ block: row }] = changeSetAdapter.createBlockRow({
         parentRef: post.ref,
     })

--- a/packages/roc-db/src/errors/OptimisticDuplicationError.ts
+++ b/packages/roc-db/src/errors/OptimisticDuplicationError.ts
@@ -1,0 +1,29 @@
+import type { Ref } from "../types/Ref"
+import { BadRequestError } from "./BadRequestError"
+
+/**
+ * Thrown by `duplicateChangeSetMutations` when it is invoked on an optimistic
+ * adapter. The primitive emits the source's mutations as N independent mutation
+ * records in the target changeSet; running the wrapping write operation
+ * optimistically would sync that operation's own mutation too, and re-executing
+ * it (on the server, or on another client via `loadMutations`) re-runs the
+ * primitive — double-executing it (silent duplicate copies, or a
+ * `ChangeSetNotEmptyError` when the target is already populated).
+ *
+ * Duplication is therefore server-authoritative only: run the wrapping operation
+ * once on a non-optimistic adapter and load the resulting mutations on clients.
+ * Do not replay the wrapping operation on clients — load the granular copies it
+ * produced instead.
+ */
+export class OptimisticDuplicationError extends BadRequestError {
+    sourceChangeSetRef: Ref
+    targetChangeSetRef: Ref
+    constructor(sourceChangeSetRef: Ref, targetChangeSetRef: Ref) {
+        super(
+            `Cannot duplicate changeSet '${sourceChangeSetRef}' into '${targetChangeSetRef}' on an optimistic adapter. duplicateChangeSetMutations is server-authoritative: run the wrapping operation once on a non-optimistic adapter and load the resulting mutations on clients (do not replay the wrapping operation).`,
+        )
+        this.name = "OptimisticDuplicationError"
+        this.sourceChangeSetRef = sourceChangeSetRef
+        this.targetChangeSetRef = targetChangeSetRef
+    }
+}

--- a/packages/roc-db/src/index.ts
+++ b/packages/roc-db/src/index.ts
@@ -11,6 +11,7 @@ export { ChangeSetIntegrityError } from "./errors/ChangeSetIntegrityError"
 export { ChangeSetNotEmptyError } from "./errors/ChangeSetNotEmptyError"
 export { NotAChangeSetError } from "./errors/NotAChangeSetError"
 export { NotAVersionError } from "./errors/NotAVersionError"
+export { OptimisticDuplicationError } from "./errors/OptimisticDuplicationError"
 export { SingletonDuplicationError } from "./errors/SingletonDuplicationError"
 export { createUniqueConstraintConflictError } from "./errors/createUniqueConstraintConflictError"
 

--- a/packages/roc-db/src/lib/assertChangeSetKind.test.ts
+++ b/packages/roc-db/src/lib/assertChangeSetKind.test.ts
@@ -17,11 +17,14 @@ const dupLoose = writeOperation("dupLoose", z.any(), (txn: any) =>
 )
 
 const makeAdapter = () =>
+    // duplicateChangeSetMutations is server-authoritative (rejects optimistic
+    // adapters), so exercise its guardrails on a non-optimistic adapter.
     createInMemoryAdapter({
         operations: [...operations, dupLoose],
         entities,
         session: { identityRef: "User/42" },
         snowflake: new Snowflake(10, 10),
+        optimistic: false,
     })
 
 describe("changeSet-kind guardrail", () => {

--- a/packages/roc-db/src/lib/duplicateChangeSetMutations.test.ts
+++ b/packages/roc-db/src/lib/duplicateChangeSetMutations.test.ts
@@ -6,6 +6,7 @@ import { BadRequestError } from "../errors/BadRequestError"
 import { ChangeSetIntegrityError } from "../errors/ChangeSetIntegrityError"
 import { ChangeSetNotEmptyError } from "../errors/ChangeSetNotEmptyError"
 import { NotFoundError } from "../errors/NotFoundError"
+import { OptimisticDuplicationError } from "../errors/OptimisticDuplicationError"
 import { SingletonDuplicationError } from "../errors/SingletonDuplicationError"
 import { entityFromRef } from "../utils/entityFromRef"
 import { Query } from "../utils/Query"
@@ -37,6 +38,65 @@ const duplicateInto = writeOperation("duplicateInto", PayloadSchema, txn =>
             txn.payload.targetRef,
         ),
     ),
+)
+// One-transaction consumer usage where the target draft carries a
+// `parents.version` (base-snapshot pointer), created in the SAME write op as the
+// duplicate call — the exact shape from the "two transactions, not one" bug
+// report. It must resolve the SOURCE base from the source's own snapshot without
+// ever reading the not-yet-committed target root.
+const OneTxnVersionSchema = z
+    .object({
+        sourceRef: DraftRefSchema,
+        postRef: z.string(),
+        versionRef: z.string(),
+    })
+    .strict()
+const duplicateOneTxnWithVersion = writeOperation(
+    "duplicateOneTxnWithVersion",
+    OneTxnVersionSchema,
+    txn => {
+        const target = txn.createRef("Draft")
+        const { sourceRef, postRef, versionRef } = txn.payload
+        return QueryChain(
+            Query(() =>
+                txn.createEntity(target, {
+                    parents: { post: postRef, version: versionRef },
+                }),
+            ),
+            // The same-transaction pending target root IS visible to the txn's
+            // own direct read (regression anchor for the report's observation).
+            Query(() => {
+                const pending = txn.readEntity(target, false)
+                if (!pending) throw new Error("pending target not visible")
+            }),
+            Query(() => txn.duplicateChangeSetMutations(sourceRef, target)),
+            Query(dup => ({ targetRef: target, ...(dup as any) })),
+        )
+    },
+)
+// A changeSet operation that reads its OWN changeSet root before creating a
+// child (a common validate/attach-against-the-root pattern). When a mutation of
+// this op is cloned into a freshly-created target, replay reads the TARGET root —
+// which, in the one-transaction pattern, is the not-yet-committed root the outer
+// op just created. The primitive must make that pending write visible to replay.
+const createReadsRoot = writeOperation(
+    "createReadsRoot",
+    z.object({ parentRef: z.string() }).strict(),
+    txn => {
+        const rowRef = txn.createRef("BlockRow")
+        return QueryChain(
+            Query(() => {
+                if (txn.changeSetRef) txn.readEntity(txn.changeSetRef)
+            }),
+            Query(() =>
+                txn.createEntity(rowRef, {
+                    children: { blocks: [] },
+                    parents: { parent: txn.payload.parentRef },
+                }),
+            ),
+        )
+    },
+    { changeSetOnly: true },
 )
 const duplicateIntoKeepRows = writeOperation(
     "duplicateIntoKeepRows",
@@ -175,7 +235,9 @@ const dupStripTags = writeOperation("dupStripTags", PayloadSchema, txn =>
 
 const localOps = [
     applyDraftTest,
+    createReadsRoot,
     duplicateInto,
+    duplicateOneTxnWithVersion,
     duplicateIntoKeepRows,
     duplicateIntoDropRows,
     duplicateIntoDropUpdates,
@@ -202,12 +264,26 @@ const makeAdapter = ({
     session?: any
     snowflake?: Snowflake
 } = {}) =>
+    // duplicateChangeSetMutations is server-authoritative: it rejects optimistic
+    // adapters (the in-memory adapter defaults to optimistic: true), so exercise
+    // it on a non-optimistic (server) adapter.
     createInMemoryAdapter({
         operations: [...operations, ...localOps],
         entities,
         session,
         snowflake,
         engine,
+        optimistic: false,
+    })
+
+const makeOptimisticAdapter = () =>
+    createInMemoryAdapter({
+        operations: [...operations, ...localOps],
+        entities,
+        session: { identityRef: "User/42" },
+        snowflake: new Snowflake(10, 10),
+        engine: makeEngine(),
+        optimistic: true,
     })
 
 // Source changeSet: a Post (base) + a BlockRow created in the changeSet + a
@@ -586,6 +662,40 @@ describe("duplicateChangeSetMutations", () => {
         expect(err.existingCount).toBeGreaterThan(0)
     })
 
+    test("throws OptimisticDuplicationError on an optimistic adapter", () => {
+        const adapter = makeOptimisticAdapter()
+        const [post] = adapter.createPost({ title: "P" })
+        const { draftRef } = seedSource(adapter, post)
+        const [target] = adapter.createDraft({ postRef: post.ref })
+
+        let err: any
+        try {
+            adapter.duplicateInto({
+                sourceRef: draftRef,
+                targetRef: target.ref,
+            })
+        } catch (e) {
+            err = e
+        }
+        expect(err).toBeInstanceOf(OptimisticDuplicationError)
+        expect(err.sourceChangeSetRef).toBe(draftRef)
+        expect(err.targetChangeSetRef).toBe(target.ref)
+        // Nothing was copied into the target.
+        expect(changeSetMutations(adapter, target.ref)).toHaveLength(0)
+    })
+
+    test("optimistic guard fires before any other validation", () => {
+        const adapter = makeOptimisticAdapter()
+        // Even a self-referential (otherwise BadRequest) call reports the
+        // optimistic rejection first — the primitive is unusable here at all.
+        expect(() =>
+            adapter.duplicateInto({
+                sourceRef: "Draft/1",
+                targetRef: "Draft/1",
+            }),
+        ).toThrow(OptimisticDuplicationError)
+    })
+
     test("throws NotFoundError when the source changeSet does not exist", () => {
         const adapter = makeAdapter()
         const [post] = adapter.createPost({ title: "P" })
@@ -777,6 +887,91 @@ describe("duplicateChangeSetMutations", () => {
         expect(newRow).not.toBe("BlockRow/900000000004")
         // The base was never materialized into the live store.
         expect(adapter._engineOpts.entities.has(basePost.ref)).toBe(false)
+    })
+
+    // Regression for the "target root must be created in a PRIOR transaction"
+    // report: creating the target changeSet root (WITH a `parents.version`) and
+    // calling the primitive in the SAME uncommitted transaction must work. The
+    // primitive seeds from the SOURCE base and never reads the target root, so a
+    // snapshot-only source base still resolves and the not-yet-committed target
+    // is never consulted.
+    test("creates the target (with version parent) and duplicates in one transaction", () => {
+        const adapter = makeAdapter()
+        // Source base lives ONLY in the source's version snapshot, never live.
+        const basePost = makeDoc("Post/920000000000", "Post", {
+            data: { title: "Base", tags: [] },
+            children: { blocks: [] },
+        })
+        const versionRef = "PostVersion/920000000001"
+        adapter._engineOpts.entities.set(
+            versionRef,
+            makeDoc(versionRef, "PostVersion", {
+                data: { version: 1, snapshot: [basePost] },
+                parents: { post: basePost.ref },
+            }),
+        )
+        const sourceRef = "Draft/920000000002"
+        adapter._engineOpts.entities.set(
+            sourceRef,
+            makeDoc(sourceRef, "Draft", {
+                parents: { post: basePost.ref, version: versionRef },
+            }),
+        )
+        adapter._engineOpts.mutations.set("Mutation/920000000003", {
+            ref: "Mutation/920000000003",
+            timestamp: TS,
+            operation: { name: "createBlockRow", version: 1 },
+            payload: { parentRef: basePost.ref },
+            log: [["BlockRow/920000000004", "create"]],
+            changeSetRef: sourceRef,
+            debounceCount: 0,
+            identityRef: "User/42",
+        })
+
+        // A live post to hang the target draft's `post` parent on.
+        const [livePost] = adapter.createPost({ title: "P" })
+
+        let result: any
+        expect(() => {
+            ;[result] = adapter.duplicateOneTxnWithVersion({
+                sourceRef,
+                postRef: livePost.ref,
+                versionRef,
+            })
+        }).not.toThrow()
+
+        // The copy landed in the freshly-created target, with a fresh row ref.
+        const persisted = changeSetMutations(adapter, result.targetRef)
+        expect(persisted).toHaveLength(1)
+        const newRow = result.refMap.get("BlockRow/920000000004")
+        expect(newRow).toBeDefined()
+        expect(newRow).not.toBe("BlockRow/920000000004")
+        // The target root was never materialized via a base-resolution read.
+        expect(adapter._engineOpts.entities.has(basePost.ref)).toBe(false)
+    })
+
+    // Regression: a cloned op that reads its own changeSet root must see the
+    // freshly-created target root during the one-transaction duplicate. The
+    // outer op creates the target root (uncommitted) and duplicates in the SAME
+    // txn; the store has no target root yet, so without surfacing the outer
+    // transaction's pending writes to replay, the cloned op's readEntity(target)
+    // throws NotFoundError(target).
+    test("cloned op that reads the changeSet root resolves the pending target in one txn", () => {
+        const adapter = makeAdapter()
+        const [post] = adapter.createPost({ title: "P" })
+        const [source] = adapter.createDraft({ postRef: post.ref })
+        // source mutation whose op reads the (source) changeSet root
+        adapter.changeSet(source.ref).createReadsRoot({ parentRef: post.ref })
+
+        let result: any
+        expect(() => {
+            ;[result] = adapter.duplicateDraft({
+                sourceRef: source.ref,
+                postRef: post.ref,
+            })
+        }).not.toThrow()
+        expect(result.mutations).toHaveLength(1)
+        expect(result.mutations[0].operation.name).toBe("createReadsRoot")
     })
 
     // Sibling of the test above, but for the *initializeChangeSet* seeding site

--- a/packages/roc-db/src/lib/duplicateChangeSetMutations.ts
+++ b/packages/roc-db/src/lib/duplicateChangeSetMutations.ts
@@ -2,6 +2,7 @@ import { BadRequestError } from "../errors/BadRequestError"
 import { ChangeSetIntegrityError } from "../errors/ChangeSetIntegrityError"
 import { ChangeSetNotEmptyError } from "../errors/ChangeSetNotEmptyError"
 import { NotFoundError } from "../errors/NotFoundError"
+import { OptimisticDuplicationError } from "../errors/OptimisticDuplicationError"
 import { SingletonDuplicationError } from "../errors/SingletonDuplicationError"
 import type { Mutation } from "../types/Mutation"
 import type { Ref } from "../types/Ref"
@@ -192,7 +193,9 @@ const buildClonePlans = (
             debounceCount: 0,
             identityRef: adapter.session.identityRef,
             sessionRef,
-            persistedAt: adapter.optimistic ? null : timestamp,
+            // Duplication is server-authoritative only (the entry point rejects
+            // optimistic adapters), so copies are always persisted records.
+            persistedAt: timestamp,
         } as Mutation
         return { operation, request, skeleton, pinningLog }
     })
@@ -288,6 +291,25 @@ const seedBaseAsync = async (
     await loadChangeSetBase(txn as any, sourceDoc, cache)
 }
 
+// Overlay the OUTER transaction's own pending writes onto the scratch cache.
+// Duplication runs inside the caller's (uncommitted) write operation, so a
+// cloned op must see what that operation has already written this transaction —
+// most importantly the freshly-created target changeSet root (a cloned op that
+// reads its own `changeSetRef` would otherwise fall through to the store, which
+// does not have the not-yet-committed root, and throw NotFoundError(target)).
+// `txn.log` holds exactly the refs this transaction created/updated/deleted (the
+// current value lives in `txn.changeSet.entities`, incl. the delete tombstone).
+// The SOURCE base was seeded first and wins: copies resolve their base against
+// the source snapshot, so we only add refs the base did not already provide.
+const seedTransactionWrites = (txn: WriteTransaction, cache: any) => {
+    for (const ref of txn.log.keys()) {
+        if (cache.entities.has(ref)) continue
+        if (txn.changeSet.entities.has(ref)) {
+            cache.entities.set(ref, txn.changeSet.entities.get(ref))
+        }
+    }
+}
+
 const duplicateSync = (
     txn: WriteTransaction,
     sourceChangeSetRef: Ref,
@@ -296,6 +318,7 @@ const duplicateSync = (
 ): DuplicateChangeSetMutationsResult => {
     const cache = generateTransactionCache(true)
     seedBaseSync(txn, sourceChangeSetRef, cache)
+    seedTransactionWrites(txn, cache)
     const existing = txn.adapter.functions.getChangeSetMutations(
         txn,
         targetChangeSetRef,
@@ -325,6 +348,7 @@ const duplicateAsync = async (
 ): Promise<DuplicateChangeSetMutationsResult> => {
     const cache = generateTransactionCache(true)
     await seedBaseAsync(txn, sourceChangeSetRef, cache)
+    seedTransactionWrites(txn, cache)
     const existing = await txn.adapter.functions.getChangeSetMutations(
         txn,
         targetChangeSetRef,
@@ -355,12 +379,26 @@ const duplicateAsync = async (
  * primary-key collisions. A transaction primitive (like `applyChangeSet`):
  * consumers call it from inside their own write operation, after creating the
  * target changeSet's root entity, so the whole duplicate is one transaction.
+ * The scratch cache is seeded from the SOURCE base (never the target), and the
+ * outer transaction's own pending writes are surfaced onto it, so creating the
+ * target root (even with a `parents.version`) in this same uncommitted
+ * transaction is supported — including when a cloned op reads its changeSet root.
  *
  * Each mutation is re-played: its operation is re-run (with the remapped /
  * transformed payload, pinning fresh refs) against a scratch cache seeded from
- * the source's base, and `finalizeMutation` derives the stored log. So the log
- * is always consistent with the payload — `transformPayload` rewriting refs
- * inside strings is reflected in reverse/delete blobs too.
+ * the source's base plus the outer transaction's pending writes, and
+ * `finalizeMutation` derives the stored log. So the log is always consistent
+ * with the payload — `transformPayload` rewriting refs inside strings is
+ * reflected in reverse/delete blobs too.
+ *
+ * **Server-authoritative only.** The primitive emits the source's mutations as N
+ * independent mutation records in the target changeSet. Running the wrapping
+ * operation optimistically would sync that operation's own mutation and re-run
+ * the primitive on replay (server, or another client via `loadMutations`),
+ * double-executing it. So it throws `OptimisticDuplicationError` on an optimistic
+ * adapter: run the wrapping operation once on a non-optimistic adapter and load
+ * the resulting mutations on clients (do not replay the wrapping operation —
+ * load the granular copies it produced instead).
  */
 export const duplicateChangeSetMutations = (
     txn: WriteTransaction,
@@ -368,6 +406,12 @@ export const duplicateChangeSetMutations = (
     targetChangeSetRef: Ref,
     options: DuplicateChangeSetMutationsOptions = {},
 ) => {
+    if (txn.adapter.optimistic) {
+        throw new OptimisticDuplicationError(
+            sourceChangeSetRef,
+            targetChangeSetRef,
+        )
+    }
     validateRefs(sourceChangeSetRef, targetChangeSetRef)
     assertChangeSetKind(txn.adapter, sourceChangeSetRef)
     assertChangeSetKind(txn.adapter, targetChangeSetRef)


### PR DESCRIPTION
## Summary

Two fixes to `txn.duplicateChangeSetMutations`, from a consumer bug report.

### 1. Bug fix — one-transaction duplicate threw `NotFoundError` for the target root

The documented one-transaction pattern (create the target changeSet root, then duplicate into it, all in one write op) threw `NotFoundError` for the **target** ref whenever a cloned op read its own changeSet root (a common validate/attach-against-the-root pattern).

**Root cause:** replay runs each cloned op against an isolated scratch cache seeded only from the *source* base. A read that misses the scratch cache falls through to the persisted store — which does **not** yet contain the target root created moments earlier by the same *uncommitted* outer operation → `NotFoundError(target)`.

**Fix:** `seedTransactionWrites` surfaces the outer transaction's own pending writes (from `txn.log`, values from `txn.changeSet.entities`, including delete tombstones) onto the replay scratch cache, so same-transaction creations — the freshly-created target root above all — are visible to replay. The source base is seeded first and takes precedence, so copies still resolve their base against the source snapshot.

No aliasing hazard: `deepPatch` is pure and `readEntity` returns copies, so overlaid references are never mutated in place; replay writes land in the scratch cache (the replay txn's changeSet), never leaking back to the outer transaction.

### 2. Make the primitive server-authoritative

`duplicateChangeSetMutations` now throws a new `OptimisticDuplicationError` when invoked on an **optimistic** adapter. The primitive emits the source's mutations as N independent mutation records; running the *wrapping* op optimistically would sync that op's own mutation and re-run the primitive on replay (server, or another client via `loadMutations`), double-executing it (duplicate copies, or `ChangeSetNotEmptyError`).

Run the wrapping op once on a non-optimistic (server) adapter and load the resulting mutations on clients; don't replay the wrapping op on clients — load the granular copies it produced.

**Action required for consumers:** the in-memory and valdres adapters default to `optimistic: true`; construct the adapter used for duplication with `optimistic: false`.

## Investigation notes

The reporter was running the published `roc-db@0.2.0-pre.99` (integrity verified against the npm tarball). The shipped bundle already contained the source-base seeding — so this was a genuine, still-present bug, not a stale build. Reproduced on valdres and postgres.

## Tests

- New shared conformance test (`testAdapterImplementation`): a source op that reads the changeSet root, duplicated in one txn — runs across **in-memory, valdres, postgres, indexed-db**.
- Core unit tests: pending-target one-txn path (incl. a target with `parents.version`), and the optimistic-adapter guard.
- Verified **red before** the fix (`NotFoundError` on the Draft target ref) and **green after**, on every adapter.
- Full suite passes (in-memory 45, valdres 50, indexed-db 46, roc-db 83, postgres 46); typecheck clean.

An independent staff-level review of the diff returned a ship verdict with no blocking or should-fix findings.

## Changeset

`roc-db` minor, `@roc-db/test-utils` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)