### PR TITLE
Include changeSetRef in initializeChangeSet error messages

### DIFF
--- a/.changeset/changeset-ref-in-error.md
+++ b/.changeset/changeset-ref-in-error.md
@@ -1,0 +1,5 @@
+---
+"roc-db": patch
+---
+
+Include the offending `changeSetRef` in the `initializeChangeSet` error messages (`The provided changeSetRef "<ref>" has already been applied` / `... does not exist`), making it easier to identify which changeSet caused the failure.

--- a/bun.lock
+++ b/bun.lock
@@ -19,10 +19,10 @@
     },
     "packages/@roc-db/in-memory": {
       "name": "@roc-db/in-memory",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.99",
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.98",
-        "roc-db": "0.2.0-pre.98",
+        "@roc-db/test-utils": "0.2.0-pre.100",
+        "roc-db": "0.2.0-pre.100",
         "zod": "4.0.14",
       },
       "peerDependencies": {
@@ -32,11 +32,11 @@
     },
     "packages/@roc-db/indexed-db": {
       "name": "@roc-db/indexed-db",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.100",
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.98",
+        "@roc-db/test-utils": "0.2.0-pre.100",
         "fake-indexeddb": "6.0.1",
-        "roc-db": "0.2.0-pre.98",
+        "roc-db": "0.2.0-pre.100",
         "zod": "4.0.14",
       },
       "peerDependencies": {
@@ -46,13 +46,13 @@
     },
     "packages/@roc-db/postgres": {
       "name": "@roc-db/postgres",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.100",
       "dependencies": {
         "postgres": "3.4.5",
       },
       "devDependencies": {
-        "@roc-db/test-utils": "0.2.0-pre.98",
-        "roc-db": "0.2.0-pre.98",
+        "@roc-db/test-utils": "0.2.0-pre.100",
+        "roc-db": "0.2.0-pre.100",
         "zod": "4.0.14",
       },
       "peerDependencies": {
@@ -62,15 +62,15 @@
     },
     "packages/@roc-db/test-utils": {
       "name": "@roc-db/test-utils",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.100",
       "devDependencies": {
         "@faker-js/faker": "9.7.0",
-        "@roc-db/in-memory": "0.2.0-pre.98",
+        "@roc-db/in-memory": "0.2.0-pre.99",
         "@types/bun": "1.2.19",
         "@types/sanitize-html": "2.13.0",
         "bun": "1.2.19",
         "expect-type": "1.2.0",
-        "roc-db": "0.2.0-pre.98",
+        "roc-db": "0.2.0-pre.100",
       },
       "peerDependencies": {
         "roc-db": ">=0.2.0-pre.98 <1.0.0",
@@ -79,15 +79,15 @@
     },
     "packages/@roc-db/valdres": {
       "name": "@roc-db/valdres",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.100",
       "devDependencies": {
         "@faker-js/faker": "9.3.0",
-        "@roc-db/test-utils": "0.2.0-pre.98",
+        "@roc-db/test-utils": "0.2.0-pre.100",
         "@types/bun": "1.2.19",
         "bun": "1.2.19",
         "expect-type": "1.1.0",
         "prettier": "3.4.1",
-        "roc-db": "0.2.0-pre.98",
+        "roc-db": "0.2.0-pre.100",
         "valdres": "0.2.0-pre.18",
       },
       "peerDependencies": {
@@ -98,11 +98,11 @@
     },
     "packages/roc-db": {
       "name": "roc-db",
-      "version": "0.2.0-pre.98",
+      "version": "0.2.0-pre.100",
       "devDependencies": {
-        "@roc-db/in-memory": "0.2.0-pre.98",
-        "@roc-db/indexed-db": "0.2.0-pre.98",
-        "@roc-db/test-utils": "0.2.0-pre.98",
+        "@roc-db/in-memory": "0.2.0-pre.99",
+        "@roc-db/indexed-db": "0.2.0-pre.100",
+        "@roc-db/test-utils": "0.2.0-pre.100",
         "@types/bun": "1.2.19",
         "bun": "1.2.19",
         "expect-type": "1.1.0",

--- a/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
+++ b/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
@@ -714,7 +714,9 @@ export const testAdapterImplementation = async <EngineOptions extends {}>(
                     parentRef: post.ref,
                     url: "https://example.com/image.png",
                 }),
-            ).toThrowError("The provided changeSetRef has already been applied")
+            ).toThrowError(
+                `The provided changeSetRef "${draftRef}" has already been applied`,
+            )
         })
 
         test("deleteDraft", async () => {

--- a/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
+++ b/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
@@ -715,7 +715,9 @@ export const testAdapterImplementation = async <EngineOptions extends {}>(
                     url: "https://example.com/image.png",
                 }),
             ).toThrowError(
-                `The provided changeSetRef "${draftRef}" has already been applied`,
+                new RegExp(
+                    `changeSetRef .*${draftRef}.* has already been applied`,
+                ),
             )
         })
 

--- a/packages/roc-db/src/lib/initializeChangeSet.ts
+++ b/packages/roc-db/src/lib/initializeChangeSet.ts
@@ -42,7 +42,7 @@ const prepareInitTransaction = (txn: Transaction, mutation: Mutation) => {
 
 const initializeChangeSetAsync = async (txn: Transaction) => {
     const changeSetDoc = await txn.readEntity(txn.changeSetRef as Ref, false)
-    verifyChangeSet(changeSetDoc)
+    verifyChangeSet(changeSetDoc, txn.changeSetRef as Ref)
     await loadChangeSetBase(txn, changeSetDoc, txn.changeSet)
     const mutations = await txn.adapter.functions.getChangeSetMutations(
         txn,
@@ -62,7 +62,7 @@ const initializeChangeSetAsync = async (txn: Transaction) => {
 
 export const initializeChangeSetSync = (txn: Transaction) => {
     const changeSetDoc = txn.readEntity(txn.changeSetRef as Ref, false)
-    verifyChangeSet(changeSetDoc)
+    verifyChangeSet(changeSetDoc, txn.changeSetRef as Ref)
     loadChangeSetBase(txn, changeSetDoc, txn.changeSet)
     const mutations = txn.adapter.functions.getChangeSetMutations(
         txn,
@@ -78,11 +78,13 @@ export const initializeChangeSetSync = (txn: Transaction) => {
     txn.changeSet.initialized = true
 }
 
-const verifyChangeSet = (changeSetDoc: any) => {
+const verifyChangeSet = (changeSetDoc: any, changeSetRef: Ref) => {
     if (!changeSetDoc)
-        throw new BadRequestError("The provided changeSetRef does not exist")
+        throw new BadRequestError(
+            `The provided changeSetRef "${changeSetRef}" does not exist`,
+        )
     if (changeSetDoc?.data?.appliedAt)
         throw new BadRequestError(
-            "The provided changeSetRef has already been applied",
+            `The provided changeSetRef "${changeSetRef}" has already been applied`,
         )
 }

--- a/packages/roc-db/src/lib/initializeChangeSet.ts
+++ b/packages/roc-db/src/lib/initializeChangeSet.ts
@@ -81,10 +81,10 @@ export const initializeChangeSetSync = (txn: Transaction) => {
 const verifyChangeSet = (changeSetDoc: any, changeSetRef: Ref) => {
     if (!changeSetDoc)
         throw new BadRequestError(
-            `The provided changeSetRef "${changeSetRef}" does not exist`,
+            `The provided changeSetRef ${JSON.stringify(changeSetRef)} does not exist`,
         )
     if (changeSetDoc?.data?.appliedAt)
         throw new BadRequestError(
-            `The provided changeSetRef "${changeSetRef}" has already been applied`,
+            `The provided changeSetRef ${JSON.stringify(changeSetRef)} has already been applied`,
         )
 }


### PR DESCRIPTION
## What

Improve the `initializeChangeSet` errors so they name the offending `changeSetRef`:

- `The provided changeSetRef "<ref>" has already been applied`
- `The provided changeSetRef "<ref>" does not exist`

Previously these messages were generic, making it hard to tell which changeSet caused the failure.

## How

Threaded `txn.changeSetRef` into `verifyChangeSet` (called from both the sync and async init paths) and interpolated it into both `BadRequestError` messages.

## Testing

- Red-first: updated the shared `applyDraft` conformance test to expect the ref in the message; confirmed it failed against the old code.
- Green after the fix.
- Full in-memory shared suite (45 pass) and `roc-db` package suite (83 pass) green. Postgres skipped (needs live DB) — the assertion is adapter-agnostic.

Includes a `patch` changeset for `roc-db`. The `bun.lock` change syncs stale workspace versions to the already-committed `package.json` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)