### PR TITLE
Fix: scope debounce matching by changeSetRef

### DIFF
--- a/.changeset/debounce-changeset-scope.md
+++ b/.changeset/debounce-changeset-scope.md
@@ -1,0 +1,14 @@
+---
+"@roc-db/in-memory": patch
+"@roc-db/valdres": patch
+"@roc-db/postgres": patch
+"@roc-db/test-utils": patch
+---
+
+Fix: scope debounce matching by `changeSetRef` in the valdres, in-memory, and postgres adapters.
+
+`findDebounceMutation` matched a debounce candidate by operation name + `payload.ref` + `identityRef` + time window, but **not** by `changeSetRef`. As a result, a debounced edit made in a new changeSet could reuse a mutation from a *different* changeSet, and `createMutation` would then inherit that mutation's stale `changeSetRef` via `{...res}`.
+
+The concrete failure: edit an entity's field in draft D1 with a debounced, changeSet-only op → apply/publish D1 (sets `appliedAt`) → within the debounce window, open a new draft D2 and edit the same field of the same entity. The client reused D1's mutation, so the new optimistic mutation carried `changeSetRef=D1`; the server then rejected it in `verifyChangeSet` with `"The provided changeSetRef has already been applied"` (500). This affected every debounced changeSet-only operation.
+
+The three adapters now require `(mutation.changeSetRef ?? null) === (request.changeSetRef ?? null)` for a debounce match, matching the behavior `@roc-db/indexed-db` already had. Covered by a new shared conformance test that runs across all adapters.

--- a/packages/@roc-db/in-memory/src/functions/findDebounceMutation.ts
+++ b/packages/@roc-db/in-memory/src/functions/findDebounceMutation.ts
@@ -16,6 +16,7 @@ export const findDebounceMutation: FindDebounceMutationFunction<
             mutation.operation.name === mutationName &&
             mutation.timestamp > thresholdTime &&
             mutation.payload?.ref === payloadRef &&
+            (mutation.changeSetRef ?? null) === (request.changeSetRef ?? null) &&
             mutation.identityRef === identityRef
         ) {
             return true

--- a/packages/@roc-db/postgres/src/functions/findDebounceMutation.ts
+++ b/packages/@roc-db/postgres/src/functions/findDebounceMutation.ts
@@ -1,3 +1,4 @@
+import { entityFromRef, idFromRef } from "roc-db"
 import type { FindDebounceMutationFunction, WriteRequest } from "roc-db"
 import type { PostgresTxnEngine } from "../types/PostgresEngineOpts"
 import { postgresRowToMutation } from "../lib/postgresRowToMutation"
@@ -22,6 +23,16 @@ export const findDebounceMutation: FindDebounceMutationFunction = (async (
     const { sqlTxn, mutationsTableName } = engineOpts
     const payloadRef = request.payload?.ref
 
+    // Debounce must be scoped to the request's changeSet. Otherwise a mutation
+    // from an already-applied changeSet gets reused and the new mutation
+    // inherits its stale (applied) changeSetRef, which the server rejects.
+    const changeSetRef = request.changeSetRef ?? null
+    const changeSetId = changeSetRef ? idFromRef(changeSetRef) : null
+    const changeSetKind = changeSetRef ? entityFromRef(changeSetRef) : null
+    const changeSetFilter = changeSetId
+        ? sqlTxn`change_set_id = ${changeSetId} AND change_set_kind = ${changeSetKind}`
+        : sqlTxn`change_set_id IS NULL`
+
     const res = await (
         payloadRef === undefined
             ? sqlTxn`
@@ -29,7 +40,8 @@ export const findDebounceMutation: FindDebounceMutationFunction = (async (
             WHERE
                 operation_name = ${mutationName} AND
                 timestamp > ${thresholdTime} AND
-                identity_ref = ${identityRef}
+                identity_ref = ${identityRef} AND
+                ${changeSetFilter}
             LIMIT 2
         `
             : sqlTxn`
@@ -38,7 +50,8 @@ export const findDebounceMutation: FindDebounceMutationFunction = (async (
                 operation_name = ${mutationName} AND
                 timestamp > ${thresholdTime} AND
                 identity_ref = ${identityRef} AND
-                log_refs = ARRAY[${payloadRef}]
+                log_refs = ARRAY[${payloadRef}] AND
+                ${changeSetFilter}
             LIMIT 2
         `
     ).catch((err: any) => {

--- a/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
+++ b/packages/@roc-db/test-utils/src/testAdapterImplementation.ts
@@ -717,6 +717,41 @@ export const testAdapterImplementation = async <EngineOptions extends {}>(
             ).toThrowError("The provided changeSetRef has already been applied")
         })
 
+        test("debounce does not collapse across changeSets (applied draft)", async () => {
+            // Repro: edit an entity's field in draft D1 with a debounced,
+            // changeSet-only op → apply/publish D1 (sets appliedAt) → open a NEW
+            // draft D2 within the debounce window → edit the SAME entity's SAME
+            // field. The debounce must NOT reuse the D1 mutation; otherwise the
+            // new mutation inherits the stale (applied) changeSetRef and the
+            // server rejects it with "changeSetRef has already been applied".
+            const [post] = await adapter1.createPost({
+                title: "Debounce repro",
+                slug: faker.lorem.slug(5),
+                tags: [],
+            })
+            const [draft1] = await adapter1.createDraft({ postRef: post.ref })
+            const draft1adapter = adapter1.changeSet(draft1.ref)
+            const [, mutation1] = await draft1adapter.updatePostDescription({
+                ref: post.ref,
+                description: "From draft 1",
+            })
+            expect(mutation1.changeSetRef).toBe(draft1.ref)
+
+            // Publish draft 1 → sets appliedAt on the changeSet.
+            await adapter1.applyDraft(draft1.ref)
+
+            // New draft, same post, same field, within the 10s debounce window.
+            const [draft2] = await adapter1.createDraft({ postRef: post.ref })
+            const draft2adapter = adapter1.changeSet(draft2.ref)
+            const [, mutation2] = await draft2adapter.updatePostDescription({
+                ref: post.ref,
+                description: "From draft 2",
+            })
+            // The debounced mutation must belong to draft 2, not applied draft 1.
+            expect(mutation2.ref).not.toBe(mutation1.ref)
+            expect(mutation2.changeSetRef).toBe(draft2.ref)
+        })
+
         test("deleteDraft", async () => {
             const { draftRef } = await prepareChangeSetTest(adapter1)
             const mutationsBefore = await adapter1.pageMutations({

--- a/packages/@roc-db/valdres/src/functions/findDebounceMutation.ts
+++ b/packages/@roc-db/valdres/src/functions/findDebounceMutation.ts
@@ -21,6 +21,7 @@ export const findDebounceMutation: FindDebounceMutationFunction<
             mutation.operation.name === mutationName &&
             mutation.timestamp > thresholdTime &&
             mutation.payload?.ref === payloadRef &&
+            (mutation.changeSetRef ?? null) === (request.changeSetRef ?? null) &&
             mutation.identityRef === identityRef
         ) {
             return true


### PR DESCRIPTION
## Problem

`findDebounceMutation` in the **valdres**, **in-memory**, and **postgres** adapters matched a debounce candidate by operation name + `payload.ref` + `identityRef` + time window, but **not** by `changeSetRef`. `createMutation` reuses the matched mutation via `{...res, debounceCount+1}`, so the new mutation inherited the matched mutation's **stale `changeSetRef`**.

### Concrete failure (reported as a 500 on sync)

1. Edit an entity's field in draft **D1** with a debounced, changeSet-only op → mutation M (`changeSetRef=D1`).
2. Apply/publish **D1** → `appliedAt` is set on the changeSet.
3. Within the debounce window, open a **new** draft **D2** and edit the same field of the same entity.
4. The client finds M (same op, same entity, same user, `<window`) and debounces onto it → the new optimistic mutation carries `changeSetRef=D1`.
5. Server `verifyChangeSet(D1)` sees `appliedAt` → throws `"The provided changeSetRef has already been applied"` → **500**.

This affected **every** debounced changeSet-only operation.

`@roc-db/indexed-db` already scoped debounce by `changeSetRef` and was the reference fix.

## Fix

The three defective adapters now require, in addition to the existing predicates:

```
(mutation.changeSetRef ?? null) === (request.changeSetRef ?? null)
```

- **valdres / in-memory**: added the predicate to the match.
- **postgres**: added a `change_set_id`/`change_set_kind` SQL filter (with `IS NULL` for non-changeSet ops), mirroring `pageMutations`.

## Test

Added a red-first shared conformance test in `testAdapterImplementation.ts` that runs across **all four adapters**. It reproduces the exact scenario (D1 edit → apply → D2 edit within window) and asserts the debounced mutation belongs to D2, not the applied D1. It failed on valdres/in-memory/postgres before the fix and passes after; indexed-db was already green.

## Verification

Full per-package suites, zero failures:

| Package | Result |
|---|---|
| in-memory | 46 pass |
| valdres | 51 pass |
| indexed-db | 47 pass |
| postgres | 47 pass (live DB) |
| roc-db core | 83 pass |

Typechecks clean for all changed packages. Changeset included (patch bumps for the three adapters + test-utils).

🤖 Generated with [Claude Code](https://claude.com/claude-code)