### PR TITLE
Detect replay divergence on mutation re-execution

### DIFF
--- a/.changeset/detect-replay-divergence.md
+++ b/.changeset/detect-replay-divergence.md
@@ -1,0 +1,11 @@
+---
+"roc-db": minor
+"@roc-db/in-memory": patch
+"@roc-db/indexed-db": patch
+---
+
+Detect replay divergence when re-executing persisted mutations on load. `loadMutations`/`persistOptimisticMutations` reconstruct client state by re-running each operation's callback rather than applying the stored effect, which silently corrupts state when an operation isn't perfectly deterministic on re-execution (e.g. a graph-restructuring op sensitive to transient state or replay order).
+
+After a replayed mutation's log is finalized, roc-db now compares the recomputed effect against the stored `mutation.log` — the set and order of entries, the structural fields each update changed, and the captured document for deletes — ignoring metadata that legitimately differs on replay (`created`/`updated`, mutation identity) and normalizing `null`/absent/`undefined`. Debounce continuations (`debounceCount > 0`) and the fresh-write path are left untouched.
+
+Divergence is surfaced via a configurable per-adapter policy (`replayDivergence`): `strict` throws a new `ReplayDivergenceError` naming the mutation, operation, and first diverging entity+field; `warn` (default) logs and continues; `off` disables the check. An `onDivergence` telemetry hook is exposed for both. The in-memory and IndexedDB adapters accept and forward the `replayDivergence` option.

--- a/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
+++ b/packages/@roc-db/in-memory/src/createInMemoryAdapter.ts
@@ -4,6 +4,7 @@ import {
     type Adapter,
     type Entity,
     type Operation,
+    type ReplayDivergenceConfig,
     type Session,
 } from "roc-db"
 import * as functions from "./functions"
@@ -19,6 +20,7 @@ export const createInMemoryAdapter = <
     optimistic = true,
     session,
     engine,
+    replayDivergence,
 }: {
     operations: Operations
     entities: Entities
@@ -31,6 +33,7 @@ export const createInMemoryAdapter = <
         entitiesUnique: Map<string, any>
         entitiesIndex: Map<string, any>
     }
+    replayDivergence?: ReplayDivergenceConfig
 }) => {
     return createAdapter(
         {
@@ -41,6 +44,7 @@ export const createInMemoryAdapter = <
             snowflake,
             optimistic,
             session,
+            replayDivergence,
         },
         engine ?? {
             entities: new Map(),

--- a/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
+++ b/packages/@roc-db/indexed-db/src/createIndexedDBAdapter.ts
@@ -4,6 +4,7 @@ import {
     type Adapter,
     type Entity,
     type Operation,
+    type ReplayDivergenceConfig,
 } from "roc-db"
 import * as functions from "./functions"
 
@@ -14,6 +15,7 @@ export const createIndexedDBAdapter = ({
     dbName = "roc-db",
     optimistic = false,
     snowflake = new Snowflake(1, 1),
+    replayDivergence,
 }: {
     operations: readonly Operation[]
     entities: readonly Entity<any>[]
@@ -21,6 +23,7 @@ export const createIndexedDBAdapter = ({
     dbName?: string
     optimistic?: boolean
     snowflake?: Snowflake
+    replayDivergence?: ReplayDivergenceConfig
 }) => {
     return createAdapter(
         {
@@ -32,6 +35,7 @@ export const createIndexedDBAdapter = ({
             session,
             snowflake,
             async: true,
+            replayDivergence,
         },
         {
             dbName,

--- a/packages/roc-db/src/createAdapter.ts
+++ b/packages/roc-db/src/createAdapter.ts
@@ -14,6 +14,7 @@ import type { AdapterFunctions } from "./types/AdapterFunctions"
 import type { Mutation } from "./types/Mutation"
 import type { Operation } from "./types/Operation"
 import type { Ref } from "./types/Ref"
+import type { ReplayDivergenceConfig } from "./types/ReplayDivergence"
 import type { RocDBRequest } from "./types/RocDBRequest"
 import { Snowflake } from "./utils/Snowflake"
 import { generateRef } from "./utils/generateRef"
@@ -43,6 +44,9 @@ type AdapterOptions<
     async?: boolean
     changeSetRef?: Ref
     optimistic?: boolean
+    // Replay-divergence detection policy, read by lib/verifyReplayDivergence on
+    // the replay/load path.
+    replayDivergence?: ReplayDivergenceConfig
     // Optional per-operation validation hooks, invoked from lib/commit.
     validateCreate?: (txn: any, document: any) => void
     validateUpdate?: (txn: any, document: any, originalDocument: any) => void

--- a/packages/roc-db/src/errors/ReplayDivergenceError.ts
+++ b/packages/roc-db/src/errors/ReplayDivergenceError.ts
@@ -1,0 +1,23 @@
+import type { ReplayDivergenceInfo } from "../types/ReplayDivergence"
+
+/**
+ * Thrown (under the `strict` replay-divergence policy) when re-executing a
+ * stored mutation on load reproduces a different effect than the one that was
+ * persisted. Names the mutation, the operation, and the first diverging
+ * entity+field with expected-vs-actual values.
+ */
+export class ReplayDivergenceError extends Error {
+    info: ReplayDivergenceInfo
+
+    constructor(info: ReplayDivergenceInfo) {
+        super(
+            `Replay divergence in mutation ${info.mutationRef}` +
+                ` (operation "${info.operation}") [${info.kind}]:` +
+                ` ${info.entity} field "${info.field}" —` +
+                ` expected ${JSON.stringify(info.expected)}` +
+                ` but recomputed ${JSON.stringify(info.actual)}`,
+        )
+        this.name = "ReplayDivergenceError"
+        this.info = info
+    }
+}

--- a/packages/roc-db/src/index.ts
+++ b/packages/roc-db/src/index.ts
@@ -13,6 +13,7 @@ export { NotAChangeSetError } from "./errors/NotAChangeSetError"
 export { NotAVersionError } from "./errors/NotAVersionError"
 export { OptimisticDuplicationError } from "./errors/OptimisticDuplicationError"
 export { SingletonDuplicationError } from "./errors/SingletonDuplicationError"
+export { ReplayDivergenceError } from "./errors/ReplayDivergenceError"
 export { createUniqueConstraintConflictError } from "./errors/createUniqueConstraintConflictError"
 
 // schemas
@@ -61,6 +62,12 @@ export type {
 } from "./lib/duplicateChangeSetMutations"
 export type { MutationRef } from "./types/MutationRef"
 export type { Operation } from "./types/Operation"
+export type {
+    ReplayDivergenceConfig,
+    ReplayDivergenceInfo,
+    ReplayDivergenceKind,
+    ReplayDivergencePolicy,
+} from "./types/ReplayDivergence"
 export type { ReadRequest } from "./types/ReadRequest"
 export type { Ref } from "./types/Ref"
 export type { Session } from "./types/Session"

--- a/packages/roc-db/src/lib/finalizeMutation.ts
+++ b/packages/roc-db/src/lib/finalizeMutation.ts
@@ -1,3 +1,4 @@
+import { verifyReplayDivergence } from "./verifyReplayDivergence"
 import type { WriteTransaction } from "./WriteTransaction"
 
 export const finalizeMutation = (
@@ -22,6 +23,14 @@ export const finalizeMutation = (
             }
         },
     )
+    // On replay/load (a re-executed mutation that carries an optimisticMutation),
+    // `txn.mutation.log` is the stored effect and `log` is what re-execution just
+    // reproduced. Compare them so a non-deterministic operation's silent
+    // divergence is caught here rather than surfacing later as corrupted state.
+    // The fresh-write path has no optimisticMutation and is left untouched.
+    if (txn.request?.type === "write" && txn.request.optimisticMutation) {
+        verifyReplayDivergence(txn, log)
+    }
     const doc = {
         ...txn.mutation,
         log,

--- a/packages/roc-db/src/lib/verifyReplayDivergence.test.ts
+++ b/packages/roc-db/src/lib/verifyReplayDivergence.test.ts
@@ -1,0 +1,399 @@
+import { createInMemoryAdapter } from "@roc-db/in-memory"
+import {
+    entities,
+    operations,
+    PostRefSchema,
+    UserRefSchema,
+} from "@roc-db/test-utils"
+import { describe, expect, test } from "bun:test"
+import { Query, QueryChain, writeOperation } from "roc-db"
+import { z } from "zod"
+import { ReplayDivergenceError } from "../errors/ReplayDivergenceError"
+import type { ReplayDivergenceConfig } from "../types/ReplayDivergence"
+import { Snowflake } from "../utils/Snowflake"
+import { compareReplayLogs } from "./verifyReplayDivergence"
+
+// --- Custom operations used to build divergent / faithful changesets ----------
+
+// Non-deterministic on replay: patches each ref, but reverses the processing
+// order on every second invocation. Authoring runs first (order preserved),
+// replay runs second (order reversed) -> the log entries land in a different
+// order. `buildReorderOp` returns a fresh op (with a fresh call counter) so
+// tests don't share state.
+const buildReorderOp = () => {
+    let calls = 0
+    return writeOperation(
+        "reorderTitles",
+        z.object({ refs: z.array(PostRefSchema) }),
+        txn => {
+            const refs = [...txn.payload.refs]
+            if (calls % 2 === 1) refs.reverse()
+            calls++
+            return QueryChain(
+                ...refs.map(ref =>
+                    Query(() =>
+                        txn.patchEntity(ref, { data: { title: `t-${ref}` } }),
+                    ),
+                ),
+            )
+        },
+    )
+}
+
+// A non-debounced title setter, so two calls produce two distinct mutations
+// (debounceCount 0) rather than a single debounced one.
+const setTitle = writeOperation(
+    "setTitle",
+    z.object({ ref: PostRefSchema, title: z.string() }),
+    txn =>
+        Query(() =>
+            txn.patchEntity(txn.payload.ref, {
+                data: { title: txn.payload.title },
+            }),
+        ),
+)
+
+// Exercises data:{} (a no-op patch that changes only metadata).
+const touchPost = writeOperation(
+    "touchPost",
+    z.object({ ref: PostRefSchema }),
+    txn => Query(() => txn.patchEntity(txn.payload.ref, { data: {} })),
+)
+
+const setPostText = writeOperation(
+    "setPostText",
+    z.object({ ref: PostRefSchema, text: z.string() }),
+    txn =>
+        Query(() =>
+            txn.patchEntity(txn.payload.ref, {
+                data: { text: txn.payload.text },
+            }),
+        ),
+)
+
+// Exercises data:{field:null} (clearing an optional field).
+const clearPostText = writeOperation(
+    "clearPostText",
+    z.object({ ref: PostRefSchema }),
+    txn =>
+        Query(() => txn.patchEntity(txn.payload.ref, { data: { text: null } })),
+)
+
+const setPostAuthor = writeOperation(
+    "setPostAuthor",
+    z.object({ ref: PostRefSchema, author: UserRefSchema }),
+    txn =>
+        Query(() =>
+            txn.patchEntity(txn.payload.ref, {
+                parents: { author: txn.payload.author },
+            }),
+        ),
+)
+
+// Exercises parents.<field> -> null.
+const clearPostAuthor = writeOperation(
+    "clearPostAuthor",
+    z.object({ ref: PostRefSchema }),
+    txn =>
+        Query(() =>
+            txn.patchEntity(txn.payload.ref, { parents: { author: null } }),
+        ),
+)
+
+const customOps = [
+    setTitle,
+    touchPost,
+    setPostText,
+    clearPostText,
+    setPostAuthor,
+    clearPostAuthor,
+]
+
+const mk = (
+    snowflake: Snowflake,
+    extraOps: any[] = [],
+    replayDivergence?: ReplayDivergenceConfig,
+): any =>
+    createInMemoryAdapter({
+        operations: [...operations, ...customOps, ...extraOps] as any,
+        entities,
+        session: { identityRef: "User/42" },
+        snowflake,
+        optimistic: true,
+        replayDivergence,
+    })
+
+// --- Integration tests (real replay through loadMutations) --------------------
+
+describe("verifyReplayDivergence (replay through loadMutations)", () => {
+    test("non-deterministic replay throws ReplayDivergenceError under strict", () => {
+        const snowflake = new Snowflake(10, 10)
+        const reorderOp = buildReorderOp()
+        const source = mk(snowflake, [reorderOp])
+
+        const [postA, createA] = source.createPost({ title: "A" })
+        const [postB, createB] = source.createPost({ title: "B" })
+        const [, reorderMut] = source.reorderTitles({
+            refs: [postA.ref, postB.ref],
+        })
+
+        // Same op instance -> its call counter is now 1, so replay reverses.
+        const target = mk(snowflake, [reorderOp], { policy: "strict" })
+
+        let thrown: unknown
+        try {
+            target.loadMutations([createA, createB, reorderMut])
+        } catch (err) {
+            thrown = err
+        }
+        expect(thrown).toBeInstanceOf(ReplayDivergenceError)
+        const info = (thrown as ReplayDivergenceError).info
+        expect(info.mutationRef).toBe(reorderMut.ref)
+        expect(info.operation).toBe("reorderTitles")
+        expect(info.kind).toBe("entry-order")
+    })
+
+    test("non-deterministic replay warns and continues under warn", () => {
+        const snowflake = new Snowflake(11, 11)
+        const reorderOp = buildReorderOp()
+        const source = mk(snowflake, [reorderOp])
+
+        const [postA, createA] = source.createPost({ title: "A" })
+        const [postB, createB] = source.createPost({ title: "B" })
+        const [, reorderMut] = source.reorderTitles({
+            refs: [postA.ref, postB.ref],
+        })
+
+        const seen: string[] = []
+        const target = mk(snowflake, [reorderOp], {
+            policy: "warn",
+            onDivergence: info => seen.push(info.kind),
+        })
+
+        const warnings: string[] = []
+        const originalWarn = console.warn
+        console.warn = (...args: unknown[]) => {
+            warnings.push(args.join(" "))
+        }
+        try {
+            expect(() =>
+                target.loadMutations([createA, createB, reorderMut]),
+            ).not.toThrow()
+        } finally {
+            console.warn = originalWarn
+        }
+
+        expect(seen).toContain("entry-order")
+        expect(warnings.some(w => w.includes("Replay divergence"))).toBe(true)
+    })
+
+    test("faithful changeset replays with zero false positives under strict", () => {
+        const snowflake = new Snowflake(12, 12)
+        const source = mk(snowflake)
+
+        const [user, createUser] = source.createUser({ email: "a@b.com" })
+        const [post, createPost] = source.createPost({ title: "Hello" })
+        const [, titleMut] = source.updatePostTitle({
+            ref: post.ref,
+            title: "Hello 2",
+        })
+        const [, tagsMut] = source.updatePostTags({
+            ref: post.ref,
+            tags: ["x", "y"],
+        })
+        const [, touchMut] = source.touchPost({ ref: post.ref }) // data:{}
+        const [, setTextMut] = source.setPostText({
+            ref: post.ref,
+            text: "hi",
+        })
+        const [, clearTextMut] = source.clearPostText({ ref: post.ref }) // data:{text:null}
+        const [, setAuthorMut] = source.setPostAuthor({
+            ref: post.ref,
+            author: user.ref,
+        })
+        const [, clearAuthorMut] = source.clearPostAuthor({ ref: post.ref }) // parents:{author:null}
+
+        const target = mk(snowflake, [], { policy: "strict" })
+
+        expect(() =>
+            target.loadMutations([
+                createUser,
+                createPost,
+                titleMut,
+                tagsMut,
+                touchMut,
+                setTextMut,
+                clearTextMut,
+                setAuthorMut,
+                clearAuthorMut,
+            ]),
+        ).not.toThrow()
+
+        const read = target.readPost(post.ref)
+        expect(read.data.title).toBe("Hello 2")
+        expect(read.data.tags).toEqual(["x", "y"])
+        expect(read.data.text).toBeUndefined()
+        expect(read.parents.author).toBeUndefined()
+    })
+
+    test("persistedAt order != causal order surfaces as a divergence", () => {
+        const snowflake = new Snowflake(13, 13)
+        const source = mk(snowflake)
+
+        const [post, createMut] = source.createPost({ title: "T" })
+        const [, m1] = source.setTitle({ ref: post.ref, title: "A" })
+        const [, m2] = source.setTitle({ ref: post.ref, title: "B" })
+
+        // All persistedAt present -> sortMutations sorts by persistedAt. Assign
+        // them so the persisted order (create, m2, m1) reverses the causal order
+        // (create, m1, m2): m2 would replay before m1, on a pre-state that never
+        // saw m1.
+        createMut.persistedAt = "2020-01-01T00:00:00.000000Z"
+        m1.persistedAt = "2020-01-01T00:00:03.000000Z"
+        m2.persistedAt = "2020-01-01T00:00:02.000000Z"
+
+        const target = mk(snowflake, [], { policy: "strict" })
+
+        let thrown: unknown
+        try {
+            target.loadMutations([createMut, m1, m2])
+        } catch (err) {
+            thrown = err
+        }
+        expect(thrown).toBeInstanceOf(ReplayDivergenceError)
+        // m2 replays first and diverges on the title's pre-value.
+        expect((thrown as ReplayDivergenceError).info.mutationRef).toBe(m2.ref)
+        expect((thrown as ReplayDivergenceError).info.kind).toBe("update-field")
+    })
+
+    test("fresh-write path is unaffected by strict policy", () => {
+        const snowflake = new Snowflake(14, 14)
+        const adapter = mk(snowflake, [], { policy: "strict" })
+
+        expect(() => adapter.createPost({ title: "X" })).not.toThrow()
+        const [post] = adapter.createPost({ title: "Y" })
+        expect(() =>
+            adapter.updatePostTitle({ ref: post.ref, title: "Z" }),
+        ).not.toThrow()
+    })
+})
+
+// --- Unit tests for the comparator itself -------------------------------------
+
+describe("compareReplayLogs", () => {
+    test("data:{} is equal to data:{field:null}", () => {
+        expect(
+            compareReplayLogs(
+                [["Post/1", "update", { data: {} }]],
+                [["Post/1", "update", { data: { narrative: null } }]],
+            ),
+        ).toBeNull()
+    })
+
+    test("parents.<field>:null is equal to absent", () => {
+        expect(
+            compareReplayLogs(
+                [["Post/1", "update", { parents: { end: null } }]],
+                [["Post/1", "update", { parents: {} }]],
+            ),
+        ).toBeNull()
+    })
+
+    test("ignores created/updated metadata", () => {
+        expect(
+            compareReplayLogs(
+                [
+                    [
+                        "Post/1",
+                        "update",
+                        {
+                            updated: { mutationRef: "M/1", timestamp: "t1" },
+                            data: { title: "a" },
+                        },
+                    ],
+                ],
+                [
+                    [
+                        "Post/1",
+                        "update",
+                        {
+                            updated: { mutationRef: "M/2", timestamp: "t2" },
+                            data: { title: "a" },
+                        },
+                    ],
+                ],
+            ),
+        ).toBeNull()
+    })
+
+    test("a metadata-only reverse-patch equals a missing third element", () => {
+        // An update that changed only metadata canonicalizes to empty; it must
+        // compare equal to an entry with no third element at all (both "empty").
+        expect(
+            compareReplayLogs(
+                [["Post/1", "update"]],
+                [
+                    [
+                        "Post/1",
+                        "update",
+                        { updated: { mutationRef: "M/2", timestamp: "t2" } },
+                    ],
+                ],
+            ),
+        ).toBeNull()
+    })
+
+    test("detects a diverged update value (array order)", () => {
+        const diff = compareReplayLogs(
+            [["Post/1", "update", { children: { items: ["a", "b"] } }]],
+            [["Post/1", "update", { children: { items: ["b", "a"] } }]],
+        )
+        expect(diff?.kind).toBe("update-field")
+        expect(diff?.field).toBe("children.items[0]")
+    })
+
+    test("detects a changed action", () => {
+        const diff = compareReplayLogs(
+            [["Post/1", "update", { data: { title: "a" } }]],
+            [["Post/1", "delete", { data: { title: "a" } }]],
+        )
+        expect(diff?.kind).toBe("action")
+    })
+
+    test("detects entry-order divergence (same set, different order)", () => {
+        const diff = compareReplayLogs(
+            [
+                ["Post/1", "update", { data: { x: 1 } }],
+                ["Post/2", "update", { data: { x: 1 } }],
+            ],
+            [
+                ["Post/2", "update", { data: { x: 1 } }],
+                ["Post/1", "update", { data: { x: 1 } }],
+            ],
+        )
+        expect(diff?.kind).toBe("entry-order")
+    })
+
+    test("detects entry-count divergence (extra recomputed entry)", () => {
+        const diff = compareReplayLogs(
+            [["Post/1", "create"]],
+            [
+                ["Post/1", "create"],
+                ["Post/2", "create"],
+            ],
+        )
+        expect(diff?.kind).toBe("entry-count")
+        expect(diff?.entity).toBe("Post/2")
+    })
+
+    test("detects a diverged update pre-value (causal reorder propagation)", () => {
+        // Two faithful updates replayed in the wrong order leave a later update
+        // reversing a different pre-value than stored.
+        const diff = compareReplayLogs(
+            [["Post/1", "update", { data: { title: "A" } }]],
+            [["Post/1", "update", { data: { title: "T" } }]],
+        )
+        expect(diff?.kind).toBe("update-field")
+        expect(diff?.field).toBe("data.title")
+    })
+})

--- a/packages/roc-db/src/lib/verifyReplayDivergence.ts
+++ b/packages/roc-db/src/lib/verifyReplayDivergence.ts
@@ -1,0 +1,266 @@
+import { ReplayDivergenceError } from "../errors/ReplayDivergenceError"
+import type {
+    ReplayDivergenceConfig,
+    ReplayDivergenceInfo,
+} from "../types/ReplayDivergence"
+import type { WriteTransaction } from "./WriteTransaction"
+
+/**
+ * A finalized mutation-log entry (the shape produced by `finalizeMutation` and
+ * persisted on `mutation.log`):
+ *   - create: `[ref, "create"]`
+ *   - update: `[ref, "update", reversePatch]`
+ *   - delete: `[ref, "delete", document]`
+ */
+type FinalizedLogEntry = [string, string, unknown?]
+
+// The comparison detail returned by the log diff, before mutation identity is
+// attached by `verifyReplayDivergence`.
+type Divergence = Omit<ReplayDivergenceInfo, "mutationRef" | "operation">
+
+// Only these structural fields are compared. Everything else on an update
+// reverse-patch or a deleted document (created/updated timestamps + mutationRef,
+// the `__` index, ref/entity identity) is metadata that legitimately differs on
+// replay and is deliberately ignored.
+const STRUCTURAL_FIELDS = ["data", "children", "parents", "ancestors"]
+
+/**
+ * Canonicalize a value so that representations which are semantically equal
+ * compare equal:
+ *   - `null` / `undefined` / absent key are all treated as absent,
+ *   - an object whose keys all normalize away collapses to absent, so
+ *     `data:{}` ≡ `data:{narrative:null}` ≡ (no data key),
+ *   - an empty array collapses to absent too.
+ * Array order and length are preserved — order is semantically meaningful for
+ * `children.items`, `parents.*`, etc., which is exactly the divergence we hunt.
+ */
+const canon = (value: unknown): unknown => {
+    if (value === null || value === undefined) return undefined
+    if (Array.isArray(value)) {
+        const arr = value.map(canon)
+        return arr.length === 0 ? undefined : arr
+    }
+    if (typeof value === "object") {
+        const source = value as Record<string, unknown>
+        const out: Record<string, unknown> = {}
+        for (const key of Object.keys(source)) {
+            const c = canon(source[key])
+            if (c !== undefined) out[key] = c
+        }
+        return Object.keys(out).length === 0 ? undefined : out
+    }
+    return value
+}
+
+// Pull just the structural fields out of a reverse-patch (update) or a captured
+// document (delete), dropping all metadata, then canonicalize for comparison.
+// Returns `undefined` (canon's "empty") for a missing/malformed entry so both
+// empty representations compare equal rather than `{}` vs `undefined`.
+const structural = (value: unknown): unknown => {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+        return undefined
+    const source = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const key of STRUCTURAL_FIELDS) {
+        if (key in source) out[key] = source[key]
+    }
+    return canon(out)
+}
+
+/**
+ * Return the first structural difference between two already-canonicalized
+ * values, as a dotted path, or `null` if equal. Used for deletes, where the
+ * stored entry captures the full pre-delete document (real forward state).
+ */
+const firstDiff = (
+    a: unknown,
+    b: unknown,
+    path: string,
+): { path: string; expected: unknown; actual: unknown } | null => {
+    if (a === b) return null
+    if (a === undefined || b === undefined)
+        return { path, expected: a, actual: b }
+
+    const aArr = Array.isArray(a)
+    const bArr = Array.isArray(b)
+    if (aArr || bArr) {
+        if (!aArr || !bArr || a.length !== b.length)
+            return { path, expected: a, actual: b }
+        for (let i = 0; i < a.length; i++) {
+            const d = firstDiff(a[i], b[i], `${path}[${i}]`)
+            if (d) return d
+        }
+        return null
+    }
+
+    if (typeof a === "object" && typeof b === "object") {
+        const keys = new Set([
+            ...Object.keys(a as object),
+            ...Object.keys(b as object),
+        ])
+        for (const key of [...keys].sort()) {
+            const d = firstDiff(
+                (a as Record<string, unknown>)[key],
+                (b as Record<string, unknown>)[key],
+                path ? `${path}.${key}` : key,
+            )
+            if (d) return d
+        }
+        return null
+    }
+
+    return { path, expected: a, actual: b }
+}
+
+const describeEntry = (entry: FinalizedLogEntry): string =>
+    `${entry[1]} ${entry[0]}`
+
+/**
+ * Compare a stored mutation log against the log recomputed by re-executing the
+ * operation, returning the first divergence or `null`.
+ *
+ * What is compared:
+ *   - the set and order of every entry (`ref` + action) — catches a different
+ *     processing order (an entry moves position, e.g. an operation that
+ *     processes items in a different order on replay), a different set of
+ *     touched entities (an entry is added/removed), and a changed action;
+ *   - for updates, the structural reverse-patch by value — catches a different
+ *     set of changed fields AND a diverged pre-state propagating from an earlier
+ *     mutation (e.g. two updates replayed in the wrong order because persisted
+ *     order disagreed with causal order);
+ *   - for deletes, the captured document's structural fields by value (the
+ *     stored delete entry holds the real pre-delete forward state).
+ *
+ * Note: debounce continuations are excluded upstream (see
+ * {@link verifyReplayDivergence}); their stored log records incremental steps
+ * that are deliberately collapsed on replay, so it can't be compared this way.
+ */
+export const compareReplayLogs = (
+    stored: unknown,
+    recomputed: unknown,
+): Divergence | null => {
+    if (!Array.isArray(stored) || !Array.isArray(recomputed)) return null
+
+    const n = Math.max(stored.length, recomputed.length)
+    for (let i = 0; i < n; i++) {
+        const s = stored[i] as FinalizedLogEntry | undefined
+        const r = recomputed[i] as FinalizedLogEntry | undefined
+
+        if (!s) {
+            return {
+                entity: r![0],
+                field: "<entry>",
+                kind: "entry-count",
+                expected: undefined,
+                actual: describeEntry(r!),
+            }
+        }
+        if (!r) {
+            return {
+                entity: s[0],
+                field: "<entry>",
+                kind: "entry-count",
+                expected: describeEntry(s),
+                actual: undefined,
+            }
+        }
+
+        const [sRef, sAction] = s
+        const [rRef, rAction] = r
+
+        if (sRef !== rRef) {
+            return {
+                entity: rRef,
+                field: "<entry>",
+                kind: "entry-order",
+                expected: describeEntry(s),
+                actual: describeEntry(r),
+            }
+        }
+        if (sAction !== rAction) {
+            return {
+                entity: sRef,
+                field: "<action>",
+                kind: "action",
+                expected: sAction,
+                actual: rAction,
+            }
+        }
+
+        if (sAction === "update") {
+            const diff = firstDiff(structural(s[2]), structural(r[2]), "")
+            if (diff) {
+                return {
+                    entity: sRef,
+                    field: diff.path || "update",
+                    kind: "update-field",
+                    expected: diff.expected,
+                    actual: diff.actual,
+                }
+            }
+        } else if (sAction === "delete") {
+            const diff = firstDiff(structural(s[2]), structural(r[2]), "")
+            if (diff) {
+                return {
+                    entity: sRef,
+                    field: diff.path || "delete",
+                    kind: "delete-field",
+                    expected: diff.expected,
+                    actual: diff.actual,
+                }
+            }
+        }
+    }
+
+    return null
+}
+
+/**
+ * On replay (a re-executed mutation carrying an `optimisticMutation`), verify
+ * the recomputed effect reproduces the stored one, and surface any divergence
+ * per the adapter's configured policy. No-op on the fresh-write path.
+ */
+export const verifyReplayDivergence = (
+    txn: WriteTransaction,
+    recomputedLog: unknown,
+): void => {
+    const cfg: ReplayDivergenceConfig | undefined = txn.adapter.replayDivergence
+    const policy = cfg?.policy ?? "warn"
+    if (policy === "off") return
+
+    // Debounce continuations (debounceCount > 0) store an incremental log
+    // relative to earlier steps that are collapsed away on replay, so their
+    // stored effect can't be compared against a from-scratch re-execution
+    // without false positives. The divergence class we target (non-deterministic
+    // operations) is never debounced, so skipping them is safe.
+    if ((txn.mutation.debounceCount ?? 0) > 0) return
+
+    const stored = txn.mutation?.log
+    if (!Array.isArray(stored)) return
+
+    const diff = compareReplayLogs(stored, recomputedLog)
+    if (!diff) return
+
+    const info: ReplayDivergenceInfo = {
+        mutationRef: txn.mutation.ref,
+        operation: txn.mutation.operation?.name,
+        ...diff,
+    }
+
+    if (cfg?.onDivergence) {
+        try {
+            cfg.onDivergence(info)
+        } catch {
+            // Telemetry must never mask (or replace) the divergence itself.
+        }
+    }
+
+    if (policy === "strict") throw new ReplayDivergenceError(info)
+
+    console.warn(
+        `[roc-db] Replay divergence in mutation ${info.mutationRef}` +
+            ` (${info.operation}) [${info.kind}] at ${info.entity}` +
+            ` field "${info.field}": expected ${JSON.stringify(info.expected)}` +
+            ` but recomputed ${JSON.stringify(info.actual)}`,
+    )
+}

--- a/packages/roc-db/src/types/AdapterOptions.ts
+++ b/packages/roc-db/src/types/AdapterOptions.ts
@@ -1,4 +1,5 @@
 import type { AdapterFunctions } from "./AdapterFunctions"
+import type { ReplayDivergenceConfig } from "./ReplayDivergence"
 import type { WriteOperation } from "./WriteOperation"
 
 export type AdapterOptions<EngineOpts extends any = any> = {
@@ -7,5 +8,7 @@ export type AdapterOptions<EngineOpts extends any = any> = {
     operations: WriteOperation[]
     session: any
     snowflake: any
+    /** Replay-divergence detection policy (see {@link ReplayDivergenceConfig}). */
+    replayDivergence?: ReplayDivergenceConfig
     [key: string]: any
 }

--- a/packages/roc-db/src/types/ReplayDivergence.ts
+++ b/packages/roc-db/src/types/ReplayDivergence.ts
@@ -1,0 +1,59 @@
+/**
+ * Replay-divergence detection: when a stored mutation is re-executed on load
+ * (replay), roc-db reconstructs client state by running the operation callback
+ * again rather than applying the stored effect. That assumes every operation is
+ * perfectly deterministic on re-execution. When it isn't, the reconstructed
+ * state silently diverges from what was originally built. These types configure
+ * the check that catches that divergence at the point it happens.
+ */
+
+export type ReplayDivergencePolicy = "off" | "warn" | "strict"
+
+/**
+ * How a recomputed mutation effect diverged from the stored one.
+ * - `entry-count`: the recomputed log has more/fewer entries than stored.
+ * - `entry-order`: an entry landed at a different position (same set, different
+ *   order — the classic "processed items in a different order on replay").
+ * - `action`: an entry for the same ref recorded a different action
+ *   (create/update/delete).
+ * - `update-field`: an update entry changed a different structural field, or the
+ *   same field to/from a different value.
+ * - `delete-field`: a delete entry's captured document differs structurally.
+ */
+export type ReplayDivergenceKind =
+    | "entry-count"
+    | "entry-order"
+    | "action"
+    | "update-field"
+    | "delete-field"
+
+export type ReplayDivergenceInfo = {
+    /** Ref of the mutation whose replay diverged. */
+    mutationRef: string
+    /** Operation name that produced the mutation (may be undefined). */
+    operation: string | undefined
+    /** Ref of the first entity whose effect diverged. */
+    entity: string
+    /** Dotted field path of the first diverging value (e.g. `children.items[2]`). */
+    field: string
+    kind: ReplayDivergenceKind
+    /** The stored (original) value. */
+    expected: unknown
+    /** The recomputed (replayed) value. */
+    actual: unknown
+}
+
+export type ReplayDivergenceConfig = {
+    /**
+     * `strict` throws a {@link ReplayDivergenceError} on the first divergence
+     * (recommended for dev/test). `warn` logs and continues, so a possibly-wrong
+     * draft still loads but the divergence is observable (recommended for prod).
+     * `off` disables the check entirely. Defaults to `warn`.
+     */
+    policy?: ReplayDivergencePolicy
+    /**
+     * Telemetry hook, invoked with divergence details before the policy acts
+     * (i.e. before a `strict` throw). Exceptions thrown by the hook are ignored.
+     */
+    onDivergence?: (info: ReplayDivergenceInfo) => void
+}


### PR DESCRIPTION
## Problem

`loadMutations` (and `persistOptimisticMutations`) reconstruct client state by **re-executing each stored mutation's operation callback** — not by applying the stored effect. That assumes every operation is perfectly deterministic on re-execution. When it isn't (a graph-restructuring op sensitive to transient state or replay order), the reconstructed state **silently diverges** from what was originally built, surfacing later as a confusing downstream validation error or corrupted state. This class of bug bricked a ShiftX process-draft on load (a decision-split ended up single-joining-and-not-last after replay).

## What this does

After a **replayed** mutation's log is finalized (`finalizeMutation`, guarded on `optimisticMutation` — the fresh-write path is untouched), compare the recomputed effect against the stored `mutation.log`:

- **entry set + order** of every `[ref, action]` — catches a different processing order (items processed in a different order on replay), an added/removed entry, or a changed action;
- **updates** — the structural reverse-patch (`data`, `children.*`, `parents.*`, `ancestors`) by value, catching a different set of changed fields *and* a diverged pre-state propagating from an earlier mutation (e.g. persisted-order ≠ causal-order);
- **deletes** — the captured document's structural fields (real forward state).

Metadata that legitimately differs on replay is ignored (`created`/`updated` timestamps + `mutationRef`, the `__` index, mutation identity), and `null`/absent-key/`undefined` are normalized (`data:{}` ≡ `data:{narrative:null}`, `parents.end:null` ≡ absent). **Debounce continuations** (`debounceCount > 0`) are skipped — their stored log records incremental steps deliberately collapsed on replay, so comparing them to a from-scratch re-execution would false-fire.

The existing `createRef` "Wrong entity"/"No next ref" throws are preserved; this catches the silent case where refs match but effects differ.

## Policy (configurable, `adapter.replayDivergence`)

- **`strict`** — throw a dedicated `ReplayDivergenceError` naming the mutation, operation, and first diverging entity+field with expected-vs-actual (recommended for dev/test).
- **`warn`** (default) — `console.warn` + `onDivergence` telemetry hook, then continue (prod: load a possibly-wrong draft, but observably).
- **`off`** — disabled.

Threaded through `@roc-db/in-memory` and `@roc-db/indexed-db`; `ReplayDivergenceError` and the config types are exported from `roc-db`.

## Design note: comparison choice

For updates we compare **recomputed reverse-patch vs stored reverse-patch by value** (both are exactly what `finalizeMutation` writes); for deletes, recomputed document vs stored document. A single-entity update whose forward value diverges but whose changed-field-set and pre-state are identical isn't detectable from the stored log (updates persist only the reverse-patch — creates carry no forward data, which is why re-execution is the design); such a divergence is instead caught at the next mutation that reads the affected field. This is still far earlier than today's silent failure.

Rebase/rewrite-history (future, esp. for changesets) will need a separate re-execution mode that skips the compare and re-persists the recomputed log — it must not go through this replay path as-is.

## Tests

14 new tests in `verifyReplayDivergence.test.ts`: non-deterministic reorder → `strict` throws / `warn` logs+continues; faithful changeset (incl. `data:{}`, `data:{text:null}`, `parents.author:null`) → zero false positives under strict; persistedAt≠causal order → surfaces as divergence; fresh-write path unaffected under strict; plus comparator unit tests (normalization, metadata-ignored, entry-order/count/action detection).

Full workspace suite green (roc-db, in-memory, indexed-db, valdres, postgres), typecheck clean, no divergence noise on faithful replays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)